### PR TITLE
feat(excel): support external (linked) images (#170)

### DIFF
--- a/docs/FROM_EXCELJS.md
+++ b/docs/FROM_EXCELJS.md
@@ -16,6 +16,7 @@ The rest of the API (workbook metadata, worksheets, rows, cells, styles, merges,
 | Preserve c15/c16 vendor extensions    | ✓ byte-preserved on clean load; silently lost on any edit | ✓ byte-preserved clean; raw-patched for safe edits; `templateMode: "strict"` fails loudly when a rebuild would drop unknown XML |
 | Chart inside chartsheet               | ✗                                                         | `workbook.addChartsheet(name, { chart: { … } })`                                                                                |
 | Pivot chart metadata                  | ✗                                                         | `worksheet.addPivotChart(...)` with drop-zones, field buttons, `c14:pivotOptions`, `c16:pivotOptions16`                         |
+| External (linked) images              | ✗ embeds bytes only                                       | `workbook.addImage({ link })` references a URL/file path (`TargetMode="External"`, `<a:blip r:link>`) — no bytes stored         |
 
 ## Translation cookbook
 

--- a/package.json
+++ b/package.json
@@ -327,23 +327,23 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@rspack/core": "^2.0.4",
+    "@rspack/core": "^2.0.5",
     "@types/node": "^25.9.1",
-    "@typescript/native-preview": "^7.0.0-dev.20260521.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260527.2",
     "@vitest/browser": "^4.1.7",
     "@vitest/browser-playwright": "^4.1.7",
     "@vitest/ui": "^4.1.7",
-    "concurrently": "^9.2.1",
+    "concurrently": "^10.0.0",
     "cross-env": "^10.1.0",
     "esbuild": "^0.28.0",
     "fast-xml-parser": "^5.8.0",
     "husky": "^9.1.7",
-    "oxfmt": "^0.51.0",
-    "oxlint": "^1.66.0",
+    "oxfmt": "^0.52.0",
+    "oxlint": "^1.67.0",
     "oxlint-tsgolint": "latest",
     "playwright": "^1.60.0",
     "rimraf": "^6.1.3",
-    "rolldown": "^1.0.2",
+    "rolldown": "^1.0.3",
     "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
@@ -358,5 +358,5 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@11.0.9"
+  "packageManager": "pnpm@11.5.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,26 +9,26 @@ importers:
   .:
     devDependencies:
       '@rspack/core':
-        specifier: ^2.0.4
-        version: 2.0.4
+        specifier: ^2.0.5
+        version: 2.0.5
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
       '@typescript/native-preview':
-        specifier: ^7.0.0-dev.20260521.1
-        version: 7.0.0-dev.20260521.1
+        specifier: ^7.0.0-dev.20260527.2
+        version: 7.0.0-dev.20260527.2
       '@vitest/browser':
         specifier: ^4.1.7
-        version: 4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
+        version: 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
       '@vitest/browser-playwright':
         specifier: ^4.1.7
-        version: 4.1.7(playwright@1.60.0)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
+        version: 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
       '@vitest/ui':
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
       concurrently:
-        specifier: ^9.2.1
-        version: 9.2.1
+        specifier: ^10.0.0
+        version: 10.0.0
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -42,11 +42,11 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       oxfmt:
-        specifier: ^0.51.0
-        version: 0.51.0
+        specifier: ^0.52.0
+        version: 0.52.0
       oxlint:
-        specifier: ^1.66.0
-        version: 1.66.0(oxlint-tsgolint@0.23.0)
+        specifier: ^1.67.0
+        version: 1.67.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
         specifier: latest
         version: 0.23.0
@@ -57,17 +57,17 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       rolldown:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.0.3
+        version: 1.0.3
       rollup-plugin-visualizer:
         specifier: ^7.0.1
-        version: 7.0.1(rolldown@1.0.2)
+        version: 7.0.1(rolldown@1.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))
 
 packages:
 
@@ -251,133 +251,133 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
-
-  '@oxc-project/types@0.130.0':
-    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
-  '@oxfmt/binding-android-arm-eabi@0.51.0':
-    resolution: {integrity: sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g==}
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxfmt/binding-android-arm-eabi@0.52.0':
+    resolution: {integrity: sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.51.0':
-    resolution: {integrity: sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg==}
+  '@oxfmt/binding-android-arm64@0.52.0':
+    resolution: {integrity: sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.51.0':
-    resolution: {integrity: sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ==}
+  '@oxfmt/binding-darwin-arm64@0.52.0':
+    resolution: {integrity: sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.51.0':
-    resolution: {integrity: sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg==}
+  '@oxfmt/binding-darwin-x64@0.52.0':
+    resolution: {integrity: sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.51.0':
-    resolution: {integrity: sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ==}
+  '@oxfmt/binding-freebsd-x64@0.52.0':
+    resolution: {integrity: sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.51.0':
-    resolution: {integrity: sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
+    resolution: {integrity: sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.51.0':
-    resolution: {integrity: sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
+    resolution: {integrity: sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.51.0':
-    resolution: {integrity: sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
+    resolution: {integrity: sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.51.0':
-    resolution: {integrity: sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ==}
+  '@oxfmt/binding-linux-arm64-musl@0.52.0':
+    resolution: {integrity: sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.51.0':
-    resolution: {integrity: sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
+    resolution: {integrity: sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.51.0':
-    resolution: {integrity: sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
+    resolution: {integrity: sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.51.0':
-    resolution: {integrity: sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ==}
+  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
+    resolution: {integrity: sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.51.0':
-    resolution: {integrity: sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA==}
+  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
+    resolution: {integrity: sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.51.0':
-    resolution: {integrity: sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw==}
+  '@oxfmt/binding-linux-x64-gnu@0.52.0':
+    resolution: {integrity: sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.51.0':
-    resolution: {integrity: sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg==}
+  '@oxfmt/binding-linux-x64-musl@0.52.0':
+    resolution: {integrity: sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.51.0':
-    resolution: {integrity: sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA==}
+  '@oxfmt/binding-openharmony-arm64@0.52.0':
+    resolution: {integrity: sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.51.0':
-    resolution: {integrity: sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g==}
+  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
+    resolution: {integrity: sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.51.0':
-    resolution: {integrity: sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w==}
+  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
+    resolution: {integrity: sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.51.0':
-    resolution: {integrity: sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.52.0':
+    resolution: {integrity: sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -412,124 +412,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.66.0':
-    resolution: {integrity: sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==}
+  '@oxlint/binding-android-arm-eabi@1.67.0':
+    resolution: {integrity: sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.66.0':
-    resolution: {integrity: sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==}
+  '@oxlint/binding-android-arm64@1.67.0':
+    resolution: {integrity: sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.66.0':
-    resolution: {integrity: sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==}
+  '@oxlint/binding-darwin-arm64@1.67.0':
+    resolution: {integrity: sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.66.0':
-    resolution: {integrity: sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==}
+  '@oxlint/binding-darwin-x64@1.67.0':
+    resolution: {integrity: sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.66.0':
-    resolution: {integrity: sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==}
+  '@oxlint/binding-freebsd-x64@1.67.0':
+    resolution: {integrity: sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
-    resolution: {integrity: sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
+    resolution: {integrity: sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
-    resolution: {integrity: sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==}
+  '@oxlint/binding-linux-arm-musleabihf@1.67.0':
+    resolution: {integrity: sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.66.0':
-    resolution: {integrity: sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==}
+  '@oxlint/binding-linux-arm64-gnu@1.67.0':
+    resolution: {integrity: sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.66.0':
-    resolution: {integrity: sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==}
+  '@oxlint/binding-linux-arm64-musl@1.67.0':
+    resolution: {integrity: sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
-    resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
+  '@oxlint/binding-linux-ppc64-gnu@1.67.0':
+    resolution: {integrity: sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
-    resolution: {integrity: sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==}
+  '@oxlint/binding-linux-riscv64-gnu@1.67.0':
+    resolution: {integrity: sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.66.0':
-    resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
+  '@oxlint/binding-linux-riscv64-musl@1.67.0':
+    resolution: {integrity: sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.66.0':
-    resolution: {integrity: sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==}
+  '@oxlint/binding-linux-s390x-gnu@1.67.0':
+    resolution: {integrity: sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.66.0':
-    resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
+  '@oxlint/binding-linux-x64-gnu@1.67.0':
+    resolution: {integrity: sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.66.0':
-    resolution: {integrity: sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==}
+  '@oxlint/binding-linux-x64-musl@1.67.0':
+    resolution: {integrity: sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.66.0':
-    resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
+  '@oxlint/binding-openharmony-arm64@1.67.0':
+    resolution: {integrity: sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.66.0':
-    resolution: {integrity: sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==}
+  '@oxlint/binding-win32-arm64-msvc@1.67.0':
+    resolution: {integrity: sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.66.0':
-    resolution: {integrity: sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==}
+  '@oxlint/binding-win32-ia32-msvc@1.67.0':
+    resolution: {integrity: sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.66.0':
-    resolution: {integrity: sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==}
+  '@oxlint/binding-win32-x64-msvc@1.67.0':
+    resolution: {integrity: sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -537,23 +537,17 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@rolldown/binding-android-arm64@1.0.1':
-    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
-    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
+    os: [android]
 
   '@rolldown/binding-darwin-arm64@1.0.2':
     resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
@@ -561,10 +555,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.1':
-    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [arm64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.2':
@@ -573,11 +567,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
-    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
-    os: [freebsd]
+    os: [darwin]
 
   '@rolldown/binding-freebsd-x64@1.0.2':
     resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
@@ -585,11 +579,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
-    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
+    cpu: [x64]
+    os: [freebsd]
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
@@ -597,12 +591,11 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
-    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
+    cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
     resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
@@ -611,12 +604,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
-    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
@@ -625,12 +618,12 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
-    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
+    cpu: [arm64]
     os: [linux]
-    libc: [glibc]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
@@ -639,10 +632,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
-    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
+    cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
@@ -653,10 +646,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
-    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -667,12 +660,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
-    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
@@ -681,11 +674,12 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
-    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -693,21 +687,21 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
-    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-wasm32-wasi@1.0.2':
     resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
-    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
+    cpu: [wasm32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.2':
     resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
@@ -715,10 +709,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
-    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [arm64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.2':
@@ -727,71 +721,77 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rspack/binding-darwin-arm64@2.0.4':
-    resolution: {integrity: sha512-0Q1QXFEsZfDc4opiDnb8q50KlBbC2VovViDaYlMJZBzvjAo325mh3itXPfz7YZ31M+TxRE7TUiJXH3ltiV1Hdg==}
+  '@rspack/binding-darwin-arm64@2.0.5':
+    resolution: {integrity: sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.4':
-    resolution: {integrity: sha512-oO5J2QYf7+H+aYRj85EiGrDOoDEE9EDDl7NgXv46iWvIF0wXowEHXqnjMFxHxRq2Vf6scT+0yYQX9blWcvMWAA==}
+  '@rspack/binding-darwin-x64@2.0.5':
+    resolution: {integrity: sha512-JBD5mCN3JKjV64Mh9nDYx8lLUrWDfEl5tLBuMkREUnqEKbo+z4nfwotyqHHM8/XgZwL+Gr7ps4GLWuQQrZB8+Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.4':
-    resolution: {integrity: sha512-BEk6mIYBK4BihW9qXXITJORrVXecTlkRjrqhgefili4xjXtLdcUnxAm9sN/2oJ8m378n2h33qDh4gr2orPBFWQ==}
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
+    resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.0.4':
-    resolution: {integrity: sha512-Hyt3z1RwNcSMIoaoWLN4Hb/696/O5JPukf8rXQASvf2UkC+X3ij7tr+8lMSYi3Zysi1QL375CnT4fNoABEW0JA==}
+  '@rspack/binding-linux-arm64-musl@2.0.5':
+    resolution: {integrity: sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.4':
-    resolution: {integrity: sha512-xHorBPBZAg0Pn9Q0k9dWZ9euowieDxcSOzQ9JhTCmhDY6wZH5M/kCBFlCs/OQeW5/NUArW3x3MwEdO/0QJHMxg==}
+  '@rspack/binding-linux-x64-gnu@2.0.5':
+    resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.0.4':
-    resolution: {integrity: sha512-QLxEGUXofF0kVNU12Y2NT3Qi9lGs+WbnYpapVeb+2IXtrAXJfU7Rhy7lAp5GLMzYMQNrKKL9SVnTWKbODbNW9Q==}
+  '@rspack/binding-linux-x64-musl@2.0.5':
+    resolution: {integrity: sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.4':
-    resolution: {integrity: sha512-YhN8HkiH46ONU9tm5dyoXDImDWGpU7E4SPqGI4OyAVF0445uIChurIUmTIOYcD6cg81GGeIjozWJOcb635Dcqw==}
+  '@rspack/binding-wasm32-wasi@2.0.5':
+    resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.4':
-    resolution: {integrity: sha512-MUlYIz82xQRN0aoiXXyEBrNVUwiOSSFRi7nuCgUKduaSdlbPWzCY31IdtOygZ06LVp5JIGUEtyqSrjQq4FrMRw==}
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
+    resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.4':
-    resolution: {integrity: sha512-D7UcIFMzlY2yhhyuW4Ej15gBWmTwUM5DxuObl3Kv31qRv/pmV3MsqUeG5m2dqLbUxzqPH87qnp0cArbkJQ1b+w==}
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
+    resolution: {integrity: sha512-nMJGIY7kvgbyMolEE7tXDe+Z9jSItDshTIqMQQkkD3WTHdjlBQozHxk4kBtKLsunO+3NkCLe5Oa3hXg1yyStIg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.4':
-    resolution: {integrity: sha512-MnYKPfdrAEbtpKg/1SZ6cNtzreIRyQJK4APbxLLPXENdTH5QXQkaTjLMKEeJcJ51FRhI/+yNpOUm2oTHdCQ1Og==}
+  '@rspack/binding-win32-x64-msvc@2.0.5':
+    resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.4':
-    resolution: {integrity: sha512-/QeJDPUw/lWkBJESG264KA9u6/rAjvoJhKncU4rkTi5Ap45kue5HTgOzr0ufxKdd2Xl72fjFBuqlKmtFDD5LiQ==}
+  '@rspack/binding@2.0.5':
+    resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
 
-  '@rspack/core@2.0.4':
-    resolution: {integrity: sha512-OuxdQeeKWQpNvFBRDOcnoSaQvp6E4APM/6JJMM/k0p6oL1TEFQVGdNu3VGY4mRAsebnNBXapMVMhj+v66Bn2pg==}
+  '@rspack/core@2.0.5':
+    resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': '>=0.5.1'
+      '@swc/helpers': ^0.5.23
     peerDependenciesMeta:
       '@module-federation/runtime-tools':
         optional: true
@@ -816,50 +816,50 @@ packages:
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-DfwzV0Qc8VDHqQXG4uc0+bbHB23u/Twrl+D7H1Izo16MmwBse3kjdKAKCJDqeboYvofx/AetKZP9yo+VxjvOWg==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-3LqSu4DlxkEfeC/Z/29QMCJn5jjkDtXI7LYuxfmjdmAatS6umDKqm8J17fnP/7fyrZUMBTIYRwSDpChGV3G1ew==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-tTtyAkx7VUgfRa+DGJa1/nR40/LsdbA5EUlSTnGV/3I6la7JB5hJxhWz+B99WjHjJbZrMrLxf6S4YHTj13GWew==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-H4+sxE9qaBbLF83wMdWE0FsgfK0Pom+/O+/oxqyGzhVkDJlNt3vfpgQZMit48/Gm44AacGfBggJ9Dhbi3aeSFw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-IMyER6SquHD/0rr7727rqTILbY7XWATFp/O1l9CRAEs9E0OY0yPmyHXFT8MYja5m4+isgsMBh618zLt8Ex1h/w==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-BGUDMjC2Z3TTdZRkGGwhBLelkP5UYgO2rbep8aF4dS3fu7T5lFPPrnfS6EgqJgie+cF5Fsev7xEq8wWyBDM+lg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-R+KzxOA6M6AX4p757xNBy8bZgNTXUxjQkEnJk2UzDpB317pwBbrpOaOaIlgB6Giw79jvKH2E428VWhXAk4ydlw==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-6I9Cv9ozwfS9zB9vRQDPIYseLX3artEO9jl3yVgLj4ishwlSF4cWAbIsjl5IztPaEgHv8coej/6tX1D0uaBzXg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-xLfDu7chsn0TJagd2oX2Z4nj3m/TRiwQmijGUgF8O0+IblKgbQcp6Egjd9VCRsGwfPidoLgElVrfcAkYfUSnGA==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-vpazOu+ozlxBo8U57YJMzsOPuxAV8H7fu36KJ8ea8At/D8pdGmOAy5TuB+9OBQV9JDe0OXJMy2kmbhOpmkTAmA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-+kcewCXj0A0bpJOx/BVjjcTs8vglcxfYuZdzyQl8O9vM1GoA7LF+jUf5Z7E2qlpKt5By/8c7wXp+4/ACM9drzQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-DBFnFE3V6AITkPO1K1VxXf3yEZKjU2FwtXlNwRqhzDu0rrL2SsJHOSrBDX+OacTxQFzZMxFcpiuhV8jHZALPEg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-Uh2PjzN3S/TGTDERgaT4O5rexiWO0nn0oXdCnBVyo0d1rbgDxq/zxsSOZdzdrQn6BRGa8x+6fVtrVFcIw4B+7w==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-1tBlErMvQgcMqqYwsx4tytupcjCJcOUXD3vBn1Wb/kAvus1FzWQAFE0fcKBvLfcqLQfTiiEwKKEtbLjGmakqqg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260521.1':
-    resolution: {integrity: sha512-JhaYbA+BVmHfya8h4QA1HsX6EZr7qaLOoOOHEwwR1ps42wN8LFDSSTbf1y2nPO3h927yh2Udl7gto1u7WGXjAQ==}
+  '@typescript/native-preview@7.0.0-dev.20260527.2':
+    resolution: {integrity: sha512-piqkDwikVeizCFqA1lcwI5F4wOAtBdxuliWe77ApBNRyBPPvfCJB+u/HYi9/8t5nd0sWvFs6/qt/AzJ1CCoykQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -908,17 +908,9 @@ packages:
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -944,28 +936,17 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  concurrently@9.2.1:
-    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
-    engines: {node: '>=18'}
+  concurrently@10.0.0:
+    resolution: {integrity: sha512-DRrk10z3sVPpguNe8od2cGNqZGqbT15rwAnxD4dG3b78mdNNb/gJyr8T834Oj518WcBmTktrt4FhdwZn09ZWSg==}
+    engines: {node: '>=22'}
     hasBin: true
 
   convert-source-map@2.0.0:
@@ -998,9 +979,6 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -1065,10 +1043,6 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
-
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -1078,10 +1052,6 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -1173,8 +1143,8 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lru-cache@11.5.0:
-    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
@@ -1204,28 +1174,34 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
-  oxfmt@0.51.0:
-    resolution: {integrity: sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==}
+  oxfmt@0.52.0:
+    resolution: {integrity: sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       svelte: ^5.0.0
+      vite-plus: '*'
     peerDependenciesMeta:
       svelte:
+        optional: true
+      vite-plus:
         optional: true
 
   oxlint-tsgolint@0.23.0:
     resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
     hasBin: true
 
-  oxlint@1.66.0:
-    resolution: {integrity: sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==}
+  oxlint@1.67.0:
+    resolution: {integrity: sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
+        optional: true
+      vite-plus:
         optional: true
 
   package-json-from-dist@1.0.1:
@@ -1275,22 +1251,18 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rolldown@1.0.1:
-    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.0.2:
-    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1322,8 +1294,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -1347,17 +1319,9 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -1366,23 +1330,19 @@ packages:
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-
-  supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+  tinyexec@1.2.3:
+    resolution: {integrity: sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
@@ -1412,8 +1372,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  vite@8.0.13:
-    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1506,16 +1466,12 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1538,17 +1494,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
 
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
@@ -1663,67 +1611,67 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nodable/entities@2.1.0': {}
-
-  '@oxc-project/types@0.130.0': {}
+  '@nodable/entities@2.1.1': {}
 
   '@oxc-project/types@0.132.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.51.0':
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.52.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.51.0':
+  '@oxfmt/binding-android-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.51.0':
+  '@oxfmt/binding-darwin-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.51.0':
+  '@oxfmt/binding-darwin-x64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.51.0':
+  '@oxfmt/binding-freebsd-x64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.51.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.51.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.51.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.51.0':
+  '@oxfmt/binding-linux-arm64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.51.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.51.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.51.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.51.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.51.0':
+  '@oxfmt/binding-linux-x64-gnu@0.52.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.51.0':
+  '@oxfmt/binding-linux-x64-musl@0.52.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.51.0':
+  '@oxfmt/binding-openharmony-arm64@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.51.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.51.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.51.0':
+  '@oxfmt/binding-win32-x64-msvc@0.52.0':
     optional: true
 
   '@oxlint-tsgolint/darwin-arm64@0.23.0':
@@ -1744,142 +1692,135 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@0.23.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.66.0':
+  '@oxlint/binding-android-arm-eabi@1.67.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.66.0':
+  '@oxlint/binding-android-arm64@1.67.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.66.0':
+  '@oxlint/binding-darwin-arm64@1.67.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.66.0':
+  '@oxlint/binding-darwin-x64@1.67.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.66.0':
+  '@oxlint/binding-freebsd-x64@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.66.0':
+  '@oxlint/binding-linux-arm64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.66.0':
+  '@oxlint/binding-linux-arm64-musl@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.66.0':
+  '@oxlint/binding-linux-riscv64-musl@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+  '@oxlint/binding-linux-s390x-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.66.0':
+  '@oxlint/binding-linux-x64-gnu@1.67.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.66.0':
+  '@oxlint/binding-linux-x64-musl@1.67.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.66.0':
+  '@oxlint/binding-openharmony-arm64@1.67.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+  '@oxlint/binding-win32-arm64-msvc@1.67.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+  '@oxlint/binding-win32-ia32-msvc@1.67.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.66.0':
+  '@oxlint/binding-win32-x64-msvc@1.67.0':
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@rolldown/binding-android-arm64@1.0.1':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
+  '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.1':
+  '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
+  '@rolldown/binding-darwin-x64@1.0.3':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+  '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
+  '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+  '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.2':
@@ -1889,70 +1830,77 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.2':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.2':
-    optional: true
-
-  '@rolldown/pluginutils@1.0.1': {}
-
-  '@rspack/binding-darwin-arm64@2.0.4':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.0.4':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@2.0.4':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.0.4':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@2.0.4':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.0.4':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.0.4':
+  '@rolldown/binding-wasm32-wasi@1.0.3':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.4':
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.4':
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.4':
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
 
-  '@rspack/binding@2.0.4':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.4
-      '@rspack/binding-darwin-x64': 2.0.4
-      '@rspack/binding-linux-arm64-gnu': 2.0.4
-      '@rspack/binding-linux-arm64-musl': 2.0.4
-      '@rspack/binding-linux-x64-gnu': 2.0.4
-      '@rspack/binding-linux-x64-musl': 2.0.4
-      '@rspack/binding-wasm32-wasi': 2.0.4
-      '@rspack/binding-win32-arm64-msvc': 2.0.4
-      '@rspack/binding-win32-ia32-msvc': 2.0.4
-      '@rspack/binding-win32-x64-msvc': 2.0.4
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
 
-  '@rspack/core@2.0.4':
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rspack/binding-darwin-arm64@2.0.5':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.0.5':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.5':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.0.5':
     dependencies:
-      '@rspack/binding': 2.0.4
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.5':
+    optional: true
+
+  '@rspack/binding@2.0.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.5
+      '@rspack/binding-darwin-x64': 2.0.5
+      '@rspack/binding-linux-arm64-gnu': 2.0.5
+      '@rspack/binding-linux-arm64-musl': 2.0.5
+      '@rspack/binding-linux-x64-gnu': 2.0.5
+      '@rspack/binding-linux-x64-musl': 2.0.5
+      '@rspack/binding-wasm32-wasi': 2.0.5
+      '@rspack/binding-win32-arm64-msvc': 2.0.5
+      '@rspack/binding-win32-ia32-msvc': 2.0.5
+      '@rspack/binding-win32-x64-msvc': 2.0.5
+
+  '@rspack/core@2.0.5':
+    dependencies:
+      '@rspack/binding': 2.0.5
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1974,61 +1922,61 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260521.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.2':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260521.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260521.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260521.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260527.2':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260521.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260527.2':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260521.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.2':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260521.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260527.2':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260521.1':
+  '@typescript/native-preview@7.0.0-dev.20260527.2':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260521.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260521.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260521.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260521.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260521.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260521.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260521.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260527.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260527.2
 
-  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)':
     dependencies:
-      '@vitest/browser': 4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
-      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))
+      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)':
+  '@vitest/browser@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))
       '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))
-      ws: 8.20.1
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -2044,13 +1992,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))':
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -2077,9 +2025,9 @@ snapshots:
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -2087,13 +2035,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  ansi-regex@5.0.1: {}
-
   ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
 
@@ -2111,16 +2053,7 @@ snapshots:
 
   chai@6.2.2: {}
 
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
+  chalk@5.6.2: {}
 
   cliui@9.0.1:
     dependencies:
@@ -2128,20 +2061,14 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
-  color-convert@2.0.1:
+  concurrently@10.0.0:
     dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
-  concurrently@9.2.1:
-    dependencies:
-      chalk: 4.1.2
+      chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
-      supports-color: 8.1.1
+      shell-quote: 1.8.4
+      supports-color: 10.2.2
       tree-kill: 1.2.2
-      yargs: 17.7.2
+      yargs: 18.0.0
 
   convert-source-map@2.0.0: {}
 
@@ -2168,8 +2095,6 @@ snapshots:
   detect-libc@2.1.2: {}
 
   emoji-regex@10.6.0: {}
-
-  emoji-regex@8.0.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -2217,7 +2142,7 @@ snapshots:
 
   fast-xml-parser@5.8.0:
     dependencies:
-      '@nodable/entities': 2.1.0
+      '@nodable/entities': 2.1.1
       fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
@@ -2247,13 +2172,9 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  has-flag@4.0.0: {}
-
   husky@9.1.7: {}
 
   is-docker@3.0.0: {}
-
-  is-fullwidth-code-point@3.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -2316,7 +2237,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lru-cache@11.5.0: {}
+  lru-cache@11.5.1: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -2343,29 +2264,29 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  oxfmt@0.51.0:
+  oxfmt@0.52.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.51.0
-      '@oxfmt/binding-android-arm64': 0.51.0
-      '@oxfmt/binding-darwin-arm64': 0.51.0
-      '@oxfmt/binding-darwin-x64': 0.51.0
-      '@oxfmt/binding-freebsd-x64': 0.51.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.51.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.51.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.51.0
-      '@oxfmt/binding-linux-arm64-musl': 0.51.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.51.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.51.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.51.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.51.0
-      '@oxfmt/binding-linux-x64-gnu': 0.51.0
-      '@oxfmt/binding-linux-x64-musl': 0.51.0
-      '@oxfmt/binding-openharmony-arm64': 0.51.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.51.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.51.0
-      '@oxfmt/binding-win32-x64-msvc': 0.51.0
+      '@oxfmt/binding-android-arm-eabi': 0.52.0
+      '@oxfmt/binding-android-arm64': 0.52.0
+      '@oxfmt/binding-darwin-arm64': 0.52.0
+      '@oxfmt/binding-darwin-x64': 0.52.0
+      '@oxfmt/binding-freebsd-x64': 0.52.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
+      '@oxfmt/binding-linux-arm64-musl': 0.52.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-musl': 0.52.0
+      '@oxfmt/binding-openharmony-arm64': 0.52.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
+      '@oxfmt/binding-win32-x64-msvc': 0.52.0
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -2376,27 +2297,27 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.66.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.66.0
-      '@oxlint/binding-android-arm64': 1.66.0
-      '@oxlint/binding-darwin-arm64': 1.66.0
-      '@oxlint/binding-darwin-x64': 1.66.0
-      '@oxlint/binding-freebsd-x64': 1.66.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.66.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.66.0
-      '@oxlint/binding-linux-arm64-gnu': 1.66.0
-      '@oxlint/binding-linux-arm64-musl': 1.66.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.66.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.66.0
-      '@oxlint/binding-linux-riscv64-musl': 1.66.0
-      '@oxlint/binding-linux-s390x-gnu': 1.66.0
-      '@oxlint/binding-linux-x64-gnu': 1.66.0
-      '@oxlint/binding-linux-x64-musl': 1.66.0
-      '@oxlint/binding-openharmony-arm64': 1.66.0
-      '@oxlint/binding-win32-arm64-msvc': 1.66.0
-      '@oxlint/binding-win32-ia32-msvc': 1.66.0
-      '@oxlint/binding-win32-x64-msvc': 1.66.0
+      '@oxlint/binding-android-arm-eabi': 1.67.0
+      '@oxlint/binding-android-arm64': 1.67.0
+      '@oxlint/binding-darwin-arm64': 1.67.0
+      '@oxlint/binding-darwin-x64': 1.67.0
+      '@oxlint/binding-freebsd-x64': 1.67.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.67.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.67.0
+      '@oxlint/binding-linux-arm64-gnu': 1.67.0
+      '@oxlint/binding-linux-arm64-musl': 1.67.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-musl': 1.67.0
+      '@oxlint/binding-linux-s390x-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-musl': 1.67.0
+      '@oxlint/binding-openharmony-arm64': 1.67.0
+      '@oxlint/binding-win32-arm64-msvc': 1.67.0
+      '@oxlint/binding-win32-ia32-msvc': 1.67.0
+      '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
 
   package-json-from-dist@1.0.1: {}
@@ -2407,7 +2328,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.5.0
+      lru-cache: 11.5.1
       minipass: 7.1.3
 
   pathe@2.0.3: {}
@@ -2434,33 +2355,10 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  require-directory@2.1.1: {}
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
-
-  rolldown@1.0.1:
-    dependencies:
-      '@oxc-project/types': 0.130.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.1
-      '@rolldown/binding-darwin-arm64': 1.0.1
-      '@rolldown/binding-darwin-x64': 1.0.1
-      '@rolldown/binding-freebsd-x64': 1.0.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
-      '@rolldown/binding-linux-arm64-gnu': 1.0.1
-      '@rolldown/binding-linux-arm64-musl': 1.0.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
-      '@rolldown/binding-linux-s390x-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-musl': 1.0.1
-      '@rolldown/binding-openharmony-arm64': 1.0.1
-      '@rolldown/binding-wasm32-wasi': 1.0.1
-      '@rolldown/binding-win32-arm64-msvc': 1.0.1
-      '@rolldown/binding-win32-x64-msvc': 1.0.1
 
   rolldown@1.0.2:
     dependencies:
@@ -2483,14 +2381,35 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.2
       '@rolldown/binding-win32-x64-msvc': 1.0.2
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.2):
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
+  rollup-plugin-visualizer@7.0.1(rolldown@1.0.3):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
-      rolldown: 1.0.2
+      rolldown: 1.0.3
 
   run-applescript@7.1.0: {}
 
@@ -2504,7 +2423,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   siginfo@2.0.0: {}
 
@@ -2522,21 +2441,11 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
 
   strip-ansi@7.2.0:
     dependencies:
@@ -2544,19 +2453,13 @@ snapshots:
 
   strnum@2.3.0: {}
 
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
-
-  supports-color@8.1.1:
-    dependencies:
-      has-flag: 4.0.0
+  supports-color@10.2.2: {}
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.1.2: {}
+  tinyexec@1.2.3: {}
 
-  tinyglobby@0.2.16:
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -2575,22 +2478,22 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0):
+  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.1
-      tinyglobby: 0.2.16
+      rolldown: 1.0.2
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
       esbuild: 0.28.0
       fsevents: 2.3.3
 
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -2604,14 +2507,14 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.3
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0))(vitest@4.1.7)
       '@vitest/ui': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
@@ -2625,19 +2528,13 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:
@@ -2648,19 +2545,7 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yargs-parser@21.1.1: {}
-
   yargs-parser@22.0.0: {}
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   yargs@18.0.0:
     dependencies:

--- a/scripts/run-examples.ts
+++ b/scripts/run-examples.ts
@@ -75,6 +75,12 @@ const examples: ExampleTest[] = [
     outputFiles: ["src/modules/excel/examples/data/checkbox.xlsx"],
     args: ["src/modules/excel/examples/data/checkbox.xlsx"]
   },
+  {
+    file: "src/modules/excel/examples/images-external.ts",
+    description: "External (linked) images — referenced, not embedded",
+    outputFiles: ["tmp/images-external.xlsx"],
+    args: ["tmp/images-external.xlsx"]
+  },
   // Formula engine examples — one per function category.
   {
     file: "src/modules/formula/examples/formula-math.ts",

--- a/src/modules/excel/README.md
+++ b/src/modules/excel/README.md
@@ -16,7 +16,7 @@ Modern TypeScript Excel Workbook Manager — read, manipulate, and write XLSX an
 - **Formulas and calculated values** — shared formulas, defined names
 - **Data validation** — list, whole, decimal, date, textLength, custom
 - **Conditional formatting** — cell value, color scale, data bar, icon set
-- **Images** — JPEG, PNG, GIF with one-cell and two-cell anchors
+- **Images** — JPEG, PNG, GIF with one-cell and two-cell anchors; embedded or external (linked) via URL/file path
 - **Hyperlinks** — internal, external, email
 - **Pivot tables** — read and preserve pivot table definitions
 - **Charts** — create/read/edit classic charts, ChartEx modern charts, combo charts, pivot charts, chartsheets, and zero-dependency SVG/PNG/PDF previews (deterministic, not Excel-pixel-perfect — see [Rendering scope](#rendering-scope))
@@ -190,6 +190,50 @@ worksheet.addImage(imageId, {
   br: { col: 3, row: 5 }
 });
 ```
+
+#### Embedded vs. external (linked) images
+
+`workbook.addImage` registers an image one of two ways:
+
+- **Embedded** — pass `buffer`, `base64`, or `filename`. The bytes are written
+  into the `.xlsx` package (`xl/media/imageN.ext`). Self-contained, but the file
+  grows with every image.
+- **Linked (external)** — pass only `link` (a URL or local file path). No bytes
+  are stored; the package keeps a relationship with `TargetMode="External"` and
+  the picture is rendered via `<a:blip r:link>`. The file stays small and the
+  image is resolved by Excel when the workbook is opened.
+
+If both bytes and a `link` are provided, **embedding wins**.
+
+```typescript
+// Linked picture from a URL — nothing is written to xl/media/.
+const urlId = workbook.addImage({ extension: "png", link: "https://example.com/logo.png" });
+worksheet.addImage(urlId, "B2:D6");
+
+// Linked picture from a local file path (resolved by Excel on open).
+const fileId = workbook.addImage({ extension: "png", link: "file:///C:/images/logo.png" });
+worksheet.addImage(fileId, "F2:H6");
+```
+
+Linked images also work as overlay watermarks:
+
+```typescript
+const wmId = workbook.addImage({ extension: "png", link: "https://example.com/draft.png" });
+worksheet.addWatermark({ imageId: wmId, mode: "overlay", opacity: 0.15 });
+```
+
+**Caveats** (inherent to Excel, not this library):
+
+- Linked images are volatile — if the target moves or the workbook is shared,
+  Excel shows a broken-image placeholder. Use embedding for self-contained files.
+- Modern Excel may refuse to auto-load remote URLs for security reasons.
+- Only **cell pictures** and **overlay watermarks** may be linked. Worksheet
+  **background** images (`addBackgroundImage`) and **header/footer (VML)**
+  watermarks (`addWatermark({ mode: "header" })`) **cannot** be linked — they
+  throw an `ImageError` if given a linked image (Excel drops such backgrounds on
+  open). Use an embedded image for those.
+
+See the runnable [`images-external.ts`](examples/images-external.ts) example.
 
 ### Tables
 

--- a/src/modules/excel/README_zh.md
+++ b/src/modules/excel/README_zh.md
@@ -16,7 +16,7 @@
 - **公式和计算值** — 共享公式、定义名称
 - **数据验证** — 列表、整数、小数、日期、文本长度、自定义
 - **条件格式** — 单元格值、色阶、数据条、图标集
-- **图片** — JPEG、PNG、GIF，支持单单元格和双单元格锚点
+- **图片** — JPEG、PNG、GIF，支持单单元格和双单元格锚点；可嵌入或通过 URL/文件路径外链
 - **超链接** — 内部链接、外部链接、邮件链接
 - **数据透视表** — 读取和保留数据透视表定义
 - **图表** — 创建/读取/编辑 classic chart、ChartEx 现代图表、组合图、数据透视图、图表工作表，并提供 SVG/PNG/PDF 预览
@@ -190,6 +190,47 @@ worksheet.addImage(imageId, {
   br: { col: 3, row: 5 }
 });
 ```
+
+#### 嵌入式 vs. 外链式（linked）图片
+
+`workbook.addImage` 有两种注册方式：
+
+- **嵌入式** —— 传 `buffer`、`base64` 或 `filename`。图片字节会写入 `.xlsx`
+  包内（`xl/media/imageN.ext`）。文件自包含，但每张图片都会增大文件体积。
+- **外链式（external）** —— 只传 `link`（URL 或本地文件路径）。不存储任何字节，
+  包内只保留一个 `TargetMode="External"` 的关系，图片通过 `<a:blip r:link>` 引用。
+  文件体积保持很小，图片在 Excel 打开工作簿时解析。
+
+若同时提供字节和 `link`，**嵌入式优先**。
+
+```typescript
+// 来自 URL 的外链图片 —— 不会写入 xl/media/。
+const urlId = workbook.addImage({ extension: "png", link: "https://example.com/logo.png" });
+worksheet.addImage(urlId, "B2:D6");
+
+// 来自本地文件路径的外链图片（Excel 打开时解析）。
+const fileId = workbook.addImage({ extension: "png", link: "file:///C:/images/logo.png" });
+worksheet.addImage(fileId, "F2:H6");
+```
+
+外链图片同样支持叠加（overlay）水印：
+
+```typescript
+const wmId = workbook.addImage({ extension: "png", link: "https://example.com/draft.png" });
+worksheet.addWatermark({ imageId: wmId, mode: "overlay", opacity: 0.15 });
+```
+
+**注意事项**（这是 Excel 本身的限制，并非本库限制）：
+
+- 外链图片是易失的 —— 一旦目标移动或工作簿被转发，Excel 会显示破图占位符。
+  需要自包含文件时请使用嵌入式。
+- 现代 Excel 出于安全考虑，可能拒绝自动加载远程 URL 图片。
+- 只有**单元格图片**和**叠加（overlay）水印**可以外链。工作表**背景图**
+  （`addBackgroundImage`）和**页眉/页脚（VML）水印**（`addWatermark({ mode: "header" })`）
+  **不能**外链 —— 传入外链图片会抛 `ImageError`（Excel 打开时会丢弃这种背景图）。
+  这两种请使用嵌入式图片。
+
+可运行示例见 [`images-external.ts`](examples/images-external.ts)。
 
 ### 表格
 

--- a/src/modules/excel/__tests__/workbook-images-external.integration.test.ts
+++ b/src/modules/excel/__tests__/workbook-images-external.integration.test.ts
@@ -1,0 +1,402 @@
+import { extractAll } from "@archive/unzip/extract";
+import { Writable } from "@stream";
+import { describe, it, expect } from "vitest";
+
+import { Workbook, WorkbookWriter } from "../../../index";
+import { expectValidXlsx } from "./helpers/expect-valid-xlsx";
+import { entryText } from "./helpers/zip-text";
+
+const REMOTE_URL = "https://example.com/assets/logo.png";
+
+/** Collect a streaming WorkbookWriter's output into a single buffer. */
+function memoryStreamWriter(): {
+  wb: InstanceType<typeof WorkbookWriter>;
+  getBytes: () => Promise<Uint8Array>;
+} {
+  const chunks: Uint8Array[] = [];
+  const stream = new Writable({
+    write(chunk: Uint8Array, _encoding: string, callback: () => void) {
+      chunks.push(chunk);
+      callback();
+    }
+  });
+  const wb = new WorkbookWriter({ stream });
+  const getBytes = async () => {
+    await wb.commit();
+    const total = chunks.reduce((n, c) => n + c.length, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      out.set(c, offset);
+      offset += c.length;
+    }
+    return out;
+  };
+  return { wb, getBytes };
+}
+
+// =============================================================================
+// External (linked) images
+//
+// An external image is referenced via `<a:blip r:link>` with a relationship
+// using `TargetMode="External"`. No image bytes are embedded in the package.
+// =============================================================================
+
+describe("Workbook external (linked) images", () => {
+  it("writes a linked image as r:link + TargetMode=External and embeds no bytes", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    ws.addImage(imageId, "B2:D6");
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    await expectValidXlsx(buffer, { label: "external image" });
+
+    const entries = await extractAll(buffer);
+
+    // No media bytes written.
+    const mediaEntries = [...entries.keys()].filter(p => p.startsWith("xl/media/"));
+    expect(mediaEntries).toHaveLength(0);
+
+    // The drawing uses r:link (not r:embed).
+    const drawingXml = entryText(entries, "xl/drawings/drawing1.xml");
+    expect(drawingXml).toBeDefined();
+    expect(drawingXml).toContain("r:link=");
+    expect(drawingXml).not.toContain("r:embed=");
+
+    // The drawing rels point at the external URL with TargetMode="External".
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels");
+    expect(relsXml).toBeDefined();
+    expect(relsXml).toContain(`Target="${REMOTE_URL}"`);
+    expect(relsXml).toContain('TargetMode="External"');
+    expect(relsXml).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"'
+    );
+
+    // No image content-type Default is registered (no part exists).
+    const contentTypes = entryText(entries, "[Content_Types].xml");
+    expect(contentTypes).toBeDefined();
+    expect(contentTypes).not.toContain('Extension="png"');
+  });
+
+  it("round-trips a linked image (link + range survive load)", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    ws.addImage(imageId, "C3:E6");
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+
+    const wb2 = new Workbook();
+    await wb2.xlsx.load(buffer);
+
+    const ws2 = wb2.getWorksheet("linked")!;
+    const images = ws2.getImages();
+    expect(images).toHaveLength(1);
+
+    const imageDesc = images[0];
+    expect(imageDesc.range!.tl.col).toBe(2);
+    expect(imageDesc.range!.tl.row).toBe(2);
+    expect(imageDesc.range!.br!.col).toBe(5);
+    expect(imageDesc.range!.br!.row).toBe(6);
+
+    const medium = wb2.getImage(imageDesc.imageId!);
+    expect(medium).toBeDefined();
+    expect(medium!.link).toBe(REMOTE_URL);
+    expect(medium!.buffer).toBeUndefined();
+    expect(medium!.base64).toBeUndefined();
+  });
+
+  it("re-writes a loaded linked image as external again (no bytes leak in)", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    ws.addImage(imageId, "A1:B2");
+
+    const first = new Uint8Array(await wb.xlsx.writeBuffer());
+
+    const wb2 = new Workbook();
+    await wb2.xlsx.load(first);
+    const second = new Uint8Array(await wb2.xlsx.writeBuffer());
+    await expectValidXlsx(second, { label: "external image roundtrip" });
+
+    const entries = await extractAll(second);
+    const mediaEntries = [...entries.keys()].filter(p => p.startsWith("xl/media/"));
+    expect(mediaEntries).toHaveLength(0);
+
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels");
+    expect(relsXml).toContain('TargetMode="External"');
+    expect(relsXml).toContain(`Target="${REMOTE_URL}"`);
+  });
+
+  it("deduplicates one rel when the same linked image is used twice", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    ws.addImage(imageId, "A1:B2");
+    ws.addImage(imageId, "D1:E2");
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    await expectValidXlsx(buffer, { label: "external dedup" });
+
+    const entries = await extractAll(buffer);
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels")!;
+    const occurrences = relsXml.split('TargetMode="External"').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("supports local file path links", async () => {
+    const localPath = "file:///C:/images/logo.png";
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+    const imageId = wb.addImage({ extension: "png", link: localPath });
+    ws.addImage(imageId, "A1:C4");
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    await expectValidXlsx(buffer, { label: "external local path" });
+
+    const entries = await extractAll(buffer);
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels")!;
+    expect(relsXml).toContain(`Target="${localPath}"`);
+    expect(relsXml).toContain('TargetMode="External"');
+  });
+
+  it("supports a linked image with a hyperlink (two distinct External rels)", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    ws.addImage(imageId, {
+      tl: { col: 1, row: 1 },
+      br: { col: 3, row: 4 },
+      hyperlinks: { hyperlink: "https://example.com/click", tooltip: "Open" }
+    });
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    await expectValidXlsx(buffer, { label: "external image + hyperlink" });
+
+    const entries = await extractAll(buffer);
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels")!;
+    // Both the image link and the hyperlink are External, with separate ids.
+    expect(relsXml).toContain(`Target="${REMOTE_URL}"`);
+    expect(relsXml).toContain('Target="https://example.com/click"');
+    const externalCount = relsXml.split('TargetMode="External"').length - 1;
+    expect(externalCount).toBe(2);
+
+    const mediaEntries = [...entries.keys()].filter(p => p.startsWith("xl/media/"));
+    expect(mediaEntries).toHaveLength(0);
+
+    // Round-trip: both the external link and the hyperlink survive a load.
+    const wb2 = new Workbook();
+    await wb2.xlsx.load(buffer);
+    const images = wb2.getWorksheet("linked")!.getImages();
+    expect(images).toHaveLength(1);
+    expect(wb2.getImage(images[0].imageId!)!.link).toBe(REMOTE_URL);
+    expect(images[0].range!.hyperlinks).toEqual({
+      hyperlink: "https://example.com/click",
+      tooltip: "Open"
+    });
+  });
+
+  it("normalises the inferred extension on read (jpg URL -> jpeg)", async () => {
+    const jpgUrl = "https://example.com/photo.jpg?cache=42";
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+    const imageId = wb.addImage({ extension: "jpeg", link: jpgUrl });
+    ws.addImage(imageId, "A1:B2");
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    const wb2 = new Workbook();
+    await wb2.xlsx.load(buffer);
+
+    const images = wb2.getWorksheet("linked")!.getImages();
+    const medium = wb2.getImage(images[0].imageId!)!;
+    expect(medium.link).toBe(jpgUrl);
+    // jpg → jpeg, query string stripped.
+    expect(medium.extension).toBe("jpeg");
+  });
+
+  it("XML-escapes special characters in the link target and round-trips them", async () => {
+    const url = "https://example.com/img.png?a=1&b=2&c=<x>";
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("linked");
+    const imageId = wb.addImage({ extension: "png", link: url });
+    ws.addImage(imageId, "A1:B2");
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    await expectValidXlsx(buffer, { label: "external link escaping" });
+
+    const entries = await extractAll(buffer);
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels")!;
+    // The raw `&`/`<`/`>` must be entity-escaped in the XML, never literal.
+    expect(relsXml).toContain("&amp;");
+    expect(relsXml).not.toContain("?a=1&b=2");
+
+    // The reader decodes them back to the exact original URL.
+    const wb2 = new Workbook();
+    await wb2.xlsx.load(buffer);
+    const images = wb2.getWorksheet("linked")!.getImages();
+    expect(wb2.getImage(images[0].imageId!)!.link).toBe(url);
+  });
+
+  it("embedding takes precedence when both buffer and link are provided", async () => {
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("mixed");
+    const imageId = wb.addImage({
+      extension: "png",
+      buffer: pngBytes as unknown as Buffer,
+      link: REMOTE_URL
+    });
+    ws.addImage(imageId, "A1:B2");
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    const entries = await extractAll(buffer);
+
+    // Bytes embedded → media part exists, blip uses r:embed, no External rel.
+    const mediaEntries = [...entries.keys()].filter(p => p.startsWith("xl/media/"));
+    expect(mediaEntries).toHaveLength(1);
+
+    const drawingXml = entryText(entries, "xl/drawings/drawing1.xml")!;
+    expect(drawingXml).toContain("r:embed=");
+    expect(drawingXml).not.toContain("r:link=");
+
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels")!;
+    expect(relsXml).not.toContain('TargetMode="External"');
+  });
+
+  it("round-trips a linked image through the streaming writer", async () => {
+    const { wb, getBytes } = memoryStreamWriter();
+
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    const ws = wb.addWorksheet("linked");
+    ws.addImage(imageId, "B2:D5");
+    ws.getCell("A1").value = "data";
+    ws.commit();
+    const out = await getBytes();
+
+    await expectValidXlsx(out, { label: "streaming external image" });
+
+    const entries = await extractAll(out);
+    const mediaEntries = [...entries.keys()].filter(p => p.startsWith("xl/media/"));
+    expect(mediaEntries).toHaveLength(0);
+
+    const wb2 = new Workbook();
+    await wb2.xlsx.load(out);
+    const images = wb2.getWorksheet("linked")!.getImages();
+    expect(images).toHaveLength(1);
+    expect(wb2.getImage(images[0].imageId!)!.link).toBe(REMOTE_URL);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Background / watermark / header
+  // ---------------------------------------------------------------------------
+
+  it("rejects an external image as a worksheet background with a clear error", async () => {
+    // Worksheet background pictures (<picture r:id>) do not support external
+    // images — Excel silently drops a background whose relationship uses
+    // TargetMode="External". So we reject it up front.
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("bg");
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    expect(() => ws.addBackgroundImage(imageId)).toThrow(/background images cannot be external/i);
+  });
+
+  it("supports an external overlay watermark (drawing rel External, no bytes)", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("wm");
+    ws.getCell("A1").value = "watermarked";
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    ws.addWatermark({ imageId, mode: "overlay", opacity: 0.2 });
+
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    await expectValidXlsx(buffer, { label: "external watermark" });
+
+    const entries = await extractAll(buffer);
+    expect([...entries.keys()].filter(p => p.startsWith("xl/media/"))).toHaveLength(0);
+
+    const drawingXml = entryText(entries, "xl/drawings/drawing1.xml")!;
+    expect(drawingXml).toContain("r:link=");
+    expect(drawingXml).not.toContain("r:embed=");
+
+    const relsXml = entryText(entries, "xl/drawings/_rels/drawing1.xml.rels")!;
+    expect(relsXml).toContain(`Target="${REMOTE_URL}"`);
+    expect(relsXml).toContain('TargetMode="External"');
+  });
+
+  it("rejects an external image for a header watermark with a clear error", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("hdr");
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    expect(() => ws.addWatermark({ imageId, mode: "header" })).toThrow(/cannot be external/i);
+  });
+
+  it("does not mutate an existing watermark when a header external call is rejected", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("hdr");
+    const embedId = wb.addImage({
+      extension: "png",
+      buffer: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) as unknown as Buffer
+    });
+    ws.addWatermark({ imageId: embedId, mode: "overlay", opacity: 0.25 });
+    const before = ws.getWatermark();
+
+    const extId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    expect(() => ws.addWatermark({ imageId: extId, mode: "header" })).toThrow(
+      /cannot be external/i
+    );
+
+    // The failed call must leave the prior watermark intact.
+    expect(ws.getWatermark()).toEqual(before);
+    expect(ws.getWatermark()!.imageId).toBe(String(embedId));
+    expect(ws.getWatermark()!.mode).toBe("overlay");
+  });
+
+  it("does not crash when a background image id is invalid", async () => {
+    const wb = new Workbook();
+    const ws = wb.addWorksheet("bg");
+    ws.getCell("A1").value = "data";
+    ws.addBackgroundImage(999);
+
+    // Must not throw; the dangling background is simply dropped.
+    const buffer = new Uint8Array(await wb.xlsx.writeBuffer());
+    await expectValidXlsx(buffer, { label: "invalid background id" });
+
+    const entries = await extractAll(buffer);
+    const wsRels = entryText(entries, "xl/worksheets/_rels/sheet1.xml.rels");
+    // No image relationship should have been written for the missing id.
+    if (wsRels) {
+      expect(wsRels).not.toContain("/relationships/image");
+    }
+  });
+
+  it("rejects a header external watermark in the streaming writer without mutating media", async () => {
+    const { wb, getBytes } = memoryStreamWriter();
+    const embedId = wb.addImage({
+      extension: "png",
+      buffer: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) as unknown as Buffer
+    });
+    const ws = wb.addWorksheet("hdr");
+    ws.addWatermark({ imageId: embedId, mode: "overlay", opacity: 0.25 });
+
+    const extId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    expect(() => ws.addWatermark({ imageId: extId, mode: "header" })).toThrow(
+      /cannot be external/i
+    );
+
+    // The overlay watermark survives and the workbook still commits cleanly.
+    expect(ws.getWatermark()!.mode).toBe("overlay");
+    ws.getCell("A1").value = "data";
+    ws.commit();
+    const out = await getBytes();
+    await expectValidXlsx(out, { label: "streaming header rejection" });
+  });
+
+  it("rejects an external background image in the streaming writer", async () => {
+    const { wb } = memoryStreamWriter();
+    const imageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+    const ws = wb.addWorksheet("bg");
+    expect(() => ws.addBackgroundImage(imageId)).toThrow(/background images cannot be external/i);
+  });
+});

--- a/src/modules/excel/examples/images-external.ts
+++ b/src/modules/excel/examples/images-external.ts
@@ -1,0 +1,116 @@
+/**
+ * Example: External (linked) images
+ *
+ * By default `workbook.addImage({ buffer | base64 | filename })` EMBEDS the
+ * image bytes inside the .xlsx package (`xl/media/imageN.ext`). Passing a
+ * `link` instead references the image EXTERNALLY — Excel stores only a
+ * relationship (`TargetMode="External"`) and a `<a:blip r:link>`, so no bytes
+ * are written into the file and its size stays small.
+ *
+ * Covers:
+ * - Linked picture placed in a cell range (`ws.addImage`)
+ * - Linked overlay watermark (`ws.addWatermark({ mode: "overlay" })`)
+ * - Embedded-vs-linked file-size comparison
+ *
+ * The `link` may be:
+ * - a local file path as a `file://` URL, e.g. `"file:///C:/images/logo.png"`, or
+ * - an http(s) URL, e.g. `"https://example.com/logo.png"`.
+ *
+ * IMPORTANT — why a linked image may show "The linked image cannot be displayed":
+ * - A `file://` link only resolves if that file actually exists on the machine
+ *   opening the workbook. This example links the REAL bundled PNG by absolute
+ *   path so it renders on the machine that generated it.
+ * - Excel desktop does NOT auto-download http(s) image links by default (a
+ *   security measure). Such links show a placeholder even when the URL is valid.
+ *   This is Excel behaviour, not a defect in the generated file.
+ *
+ * Other caveats:
+ * - Linked images are volatile: if the target moves or the workbook is sent to
+ *   someone else, Excel shows a broken-image placeholder. Embed for portability.
+ * - Only cell pictures and overlay watermarks may be external. Worksheet
+ *   BACKGROUND images and HEADER/FOOTER (VML) watermarks cannot be linked —
+ *   `addBackgroundImage` / `addWatermark({ mode: "header" })` throw if given a
+ *   linked image (Excel drops such backgrounds on open). Use an embedded image.
+ *
+ * Run: `npx tsx src/modules/excel/examples/images-external.ts [outFile.xlsx]`
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { HrStopwatch } from "@excel/examples/utils/hr-stopwatch";
+
+import { Workbook } from "../../../index";
+
+const exampleDir = path.dirname(fileURLToPath(import.meta.url));
+
+// Output file: passed via argv, otherwise written under the project tmp/ dir.
+const filename = process.argv[2] ?? path.join(exampleDir, "../../../../tmp/images-external.xlsx");
+fs.mkdirSync(path.dirname(filename), { recursive: true });
+
+// A small real PNG bundled with the examples.
+const localPng = path.join(exampleDir, "data/image2.png");
+
+// `file://` URL pointing at that REAL local file — renders on this machine.
+const LOCAL_FILE_URL = pathToFileURL(localPng).href;
+
+// A publicly reachable http(s) URL (the same PNG, served from the repo).
+// NOTE: Excel desktop will NOT auto-download this — it shows a placeholder by
+// design. The relationship in the .xlsx is still correct.
+const REMOTE_URL =
+  "https://raw.githubusercontent.com/cjnoname/excelts/main/src/modules/excel/examples/data/image2.png";
+
+// ---------------------------------------------------------------------------
+// 1. A workbook with EXTERNAL (linked) images — no bytes embedded.
+// ---------------------------------------------------------------------------
+const wb = new Workbook();
+const ws = wb.addWorksheet("linked-images");
+
+ws.getCell("A1").value = "Linked images are referenced, not embedded — the file stays small.";
+ws.getCell("A2").value =
+  "Left: local file:// link (renders here). Right: https link (Excel blocks auto-download).";
+
+// (a) A linked picture from a REAL local file — this one displays on this machine.
+const localLinkId = wb.addImage({ extension: "png", link: LOCAL_FILE_URL });
+ws.addImage(localLinkId, "B4:E11");
+
+// (b) A linked picture from an http(s) URL — valid rel, but Excel won't fetch it.
+const urlImageId = wb.addImage({ extension: "png", link: REMOTE_URL });
+ws.addImage(urlImageId, "G4:J11");
+
+// (c) A linked overlay watermark on a second sheet (transparency via opacity).
+const wmSheet = wb.addWorksheet("linked-watermark");
+wmSheet.getCell("A1").value = "This sheet has a linked overlay watermark.";
+const wmImageId = wb.addImage({ extension: "png", link: LOCAL_FILE_URL });
+wmSheet.addWatermark({ imageId: wmImageId, mode: "overlay", opacity: 0.15 });
+
+// The following would THROW — background and header watermarks must be embedded:
+//   wmSheet.addWatermark({ imageId: wmImageId, mode: "header" });
+//   ws.addBackgroundImage(wmImageId);
+//   // ImageError: ...cannot be external (linked) images.
+
+const stopwatch = new HrStopwatch();
+stopwatch.start();
+try {
+  await wb.xlsx.writeFile(filename);
+  console.log("Done. Wrote linked-image workbook to:", filename);
+  console.log("Time taken (us):", stopwatch.microseconds);
+} catch (error) {
+  console.error((error as Error).stack);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Size comparison: embedded vs linked.
+// ---------------------------------------------------------------------------
+const embeddedWb = new Workbook();
+const embeddedWs = embeddedWb.addWorksheet("embedded");
+const embeddedId = embeddedWb.addImage({ buffer: fs.readFileSync(localPng), extension: "png" });
+embeddedWs.addImage(embeddedId, "B3:E10");
+const embeddedBytes = new Uint8Array(await embeddedWb.xlsx.writeBuffer());
+
+const linkedBytes = fs.statSync(filename).size;
+console.log("");
+console.log("Size comparison (single image):");
+console.log(`  embedded workbook: ${embeddedBytes.length} bytes`);
+console.log(`  linked   workbook: ${linkedBytes} bytes (2 sheets, but no image bytes)`);

--- a/src/modules/excel/stream/workbook-writer.browser.ts
+++ b/src/modules/excel/stream/workbook-writer.browser.ts
@@ -19,7 +19,7 @@ import type {
   WorkbookProtection,
   AddWorksheetOptions
 } from "@excel/types";
-import { filterDrawingAnchors } from "@excel/utils/drawing-utils";
+import { filterDrawingAnchors, isExternalImage } from "@excel/utils/drawing-utils";
 import {
   drawingPath,
   drawingRelsPath,
@@ -564,6 +564,23 @@ export abstract class WorkbookWriterBase<TWorksheetWriter extends WorksheetWrite
     return this._worksheets.length || 1;
   }
 
+  /**
+   * Register an image with the workbook and return its numeric id.
+   *
+   * Supply `buffer`/`base64`/`filename` to **embed** the bytes, or only `link`
+   * (a URL or local file path) to reference it **externally** — in which case
+   * no bytes are written into the package and the relationship is emitted with
+   * `TargetMode="External"`. If both are provided, embedding wins.
+   *
+   * Linked images work with cell pictures and overlay watermarks; worksheet
+   * background images and header/footer (VML) watermarks cannot be linked.
+   *
+   * @example
+   * ```typescript
+   * const id = wb.addImage({ extension: "png", link: "https://example.com/logo.png" });
+   * ws.addImage(id, "B2:D6");
+   * ```
+   */
   addImage(image: ImageData): number {
     const id = this.media.length;
     const medium: Medium = {
@@ -699,6 +716,11 @@ export abstract class WorkbookWriterBase<TWorksheetWriter extends WorksheetWrite
     return Promise.all(
       this.media.map(async medium => {
         if (medium.type === "image") {
+          // External (linked) images carry only a `link` target — no bytes
+          // are written into the package.
+          if (isExternalImage(medium)) {
+            return;
+          }
           const filename = mediaPath(medium.name);
           if (medium.buffer) {
             this._addFile(medium.buffer, filename);

--- a/src/modules/excel/stream/workbook-writer.ts
+++ b/src/modules/excel/stream/workbook-writer.ts
@@ -12,6 +12,7 @@ import {
   type ZlibOptions
 } from "@excel/stream/workbook-writer.browser";
 import { WorksheetWriter } from "@excel/stream/worksheet-writer";
+import { isExternalImage } from "@excel/utils/drawing-utils";
 import { mediaPath } from "@excel/utils/ooxml-paths";
 import { readFileBytes, createWriteStream } from "@utils/fs";
 
@@ -56,6 +57,11 @@ class WorkbookWriter extends WorkbookWriterBase<WorksheetWriter> {
     return Promise.all(
       this.media.map(async medium => {
         if (medium.type === "image") {
+          // External (linked) images carry only a `link` target — no bytes
+          // are written into the package.
+          if (isExternalImage(medium)) {
+            return;
+          }
           const filename = mediaPath(medium.name);
           // Node.js: support loading from file
           if (medium.filename) {

--- a/src/modules/excel/stream/worksheet-writer.ts
+++ b/src/modules/excel/stream/worksheet-writer.ts
@@ -2,7 +2,12 @@ import { Anchor } from "@excel/anchor";
 import type { Cell } from "@excel/cell";
 import { Column } from "@excel/column";
 import { DataValidations } from "@excel/data-validations";
-import { ExcelStreamStateError, MergeConflictError, RowOutOfBoundsError } from "@excel/errors";
+import {
+  ExcelStreamStateError,
+  ImageError,
+  MergeConflictError,
+  RowOutOfBoundsError
+} from "@excel/errors";
 import { Dimensions } from "@excel/range";
 import { Row } from "@excel/row";
 import { SheetCommentsWriter } from "@excel/stream/sheet-comments-writer";
@@ -11,6 +16,7 @@ import type { Medium as WriterMedium } from "@excel/stream/workbook-writer";
 import { colCache } from "@excel/utils/col-cache";
 import {
   buildDrawingAnchorsAndRels,
+  isExternalImage,
   type DrawingAnchor,
   type DrawingRel
 } from "@excel/utils/drawing-utils";
@@ -689,6 +695,14 @@ class WorksheetWriter {
   // =========================================================================
 
   addBackgroundImage(imageId: string | number): void {
+    const bookImage = this._workbook.getImage(Number(imageId));
+    if (bookImage && isExternalImage(bookImage)) {
+      throw new ImageError(
+        "Background images cannot be external (linked) images. " +
+          "Use an embedded image (buffer/base64/filename). " +
+          "External images are only supported for cell pictures and overlay watermarks."
+      );
+    }
     this._background = {
       imageId: Number(imageId)
     };
@@ -724,8 +738,30 @@ class WorksheetWriter {
   /**
    * Add a watermark to the worksheet using an image from `WorkbookWriter.addImage()`.
    * Supports overlay mode (DrawingML with transparency) and header mode (VML behind content).
+   *
+   * `mode: "overlay"` supports external (linked) images; `mode: "header"` does
+   * not — VML header/footer images require embedded media, so a linked image
+   * with `mode: "header"` throws an `ImageError`.
+   *
+   * @throws {ImageError} If `mode: "header"` is used with an external (linked) image.
    */
   addWatermark(options: WatermarkOptions): void {
+    const mode = options.mode ?? "overlay";
+
+    // Validate BEFORE mutating any state: VML header/footer images use
+    // embedded media; external (linked) images are not representable here.
+    // Reject them up front so a failed call leaves existing watermark media
+    // untouched (no partial mutation).
+    if (mode === "header") {
+      const bookImage = this._workbook.getImage(Number(options.imageId));
+      if (bookImage && isExternalImage(bookImage)) {
+        throw new ImageError(
+          "Header watermark images cannot be external (linked) images. " +
+            "Use an embedded image (buffer/base64/filename), or use overlay mode for linked images."
+        );
+      }
+    }
+
     // Remove existing watermark entries (both stored type tags)
     this._media = this._media.filter(m => (m as any)._watermarkTag !== true);
 
@@ -734,7 +770,7 @@ class WorksheetWriter {
 
     this._watermark = {
       imageId: String(options.imageId),
-      mode: options.mode ?? "overlay",
+      mode,
       opacity,
       headerWidth: options.headerWidth,
       headerHeight: options.headerHeight,
@@ -1115,6 +1151,8 @@ class WorksheetWriter {
         if (!image) {
           return;
         }
+        // Background images are always embedded — external (linked) images are
+        // rejected up front in addBackgroundImage (Excel drops them).
         const pictureId = this._sheetRelsWriter.addMedia({
           Target: mediaRelTargetFromRels(image.name),
           Type: RelType.Image

--- a/src/modules/excel/types.ts
+++ b/src/modules/excel/types.ts
@@ -679,6 +679,23 @@ export interface ImageData {
   base64?: string;
   filename?: string;
   buffer?: Buffer;
+  /**
+   * Reference the image as an **external link** instead of embedding its bytes.
+   *
+   * When set (and `buffer`/`base64`/`filename` are all omitted), the image is
+   * written as a linked DrawingML picture (`<a:blip r:link>`) whose relationship
+   * uses `TargetMode="External"`. No bytes are stored in the `.xlsx` package, so
+   * the file size stays small. The value may be either:
+   *
+   * - an absolute/relative URL (e.g. `"https://example.com/logo.png"`), or
+   * - a local file path (e.g. `"file:///C:/images/logo.png"` or `"images/logo.png"`).
+   *
+   * Note: Excel treats linked images as volatile — a moved/missing target shows a
+   * broken-image placeholder, and modern Excel may not auto-load remote URLs for
+   * security reasons. Use embedding (`buffer`/`base64`) when self-contained files
+   * are required.
+   */
+  link?: string;
 }
 
 export interface ImagePosition {

--- a/src/modules/excel/utils/drawing-utils.ts
+++ b/src/modules/excel/utils/drawing-utils.ts
@@ -19,6 +19,11 @@ export interface DrawingAnchor {
     hyperlinks?: { tooltip?: string; rId: string };
     /** Alpha modulation for transparency (OOXML percentage, e.g. 15000 = 15%). */
     alphaModFix?: number;
+    /**
+     * When true, the picture references an external linked image
+     * (`<a:blip r:link>`) instead of an embedded one (`<a:blip r:embed>`).
+     */
+    external?: boolean;
   };
   range: any;
 }
@@ -44,6 +49,20 @@ interface ImageMedium {
 }
 
 /**
+ * Minimal shape of a book-level media entry needed by the embed-vs-link
+ * decision and image-rel construction. Carries the optional link target plus
+ * the three mutually-exclusive embedded byte sources.
+ */
+export interface MediaLike {
+  name?: string;
+  extension?: string;
+  link?: string;
+  buffer?: unknown;
+  base64?: unknown;
+  filename?: unknown;
+}
+
+/**
  * Resolves a media filename into the drawing-level relative target path.
  *
  * In the non-streaming path, media entries have separate `name` and `extension`
@@ -64,14 +83,73 @@ export function resolveMediaTarget(medium: { name?: string; extension?: string }
   return mediaRelTargetFromRels(filename);
 }
 
+/**
+ * Determine whether a media entry is an **external (linked) image** rather than
+ * an embedded one. An external image carries a `link` target and supplies no
+ * embedded bytes (`buffer`/`base64`/`filename`). Embedding always takes
+ * precedence: if any byte source is present the image is embedded even if a
+ * `link` was also provided.
+ */
+export function isExternalImage(medium: MediaLike): boolean {
+  return !!medium.link && medium.buffer == null && medium.base64 == null && medium.filename == null;
+}
+
+/**
+ * Best-effort image extension inference from an external link's path.
+ *
+ * Normalises to the extension vocabulary used by `ImageData`
+ * (`"jpeg" | "png" | "gif"`); unknown extensions fall back to `"png"`.
+ * The extension is advisory only for linked images — the relationship
+ * Target carries the real reference — but keeping it within the documented
+ * set avoids surprising consumers that branch on `medium.extension`.
+ */
+export function inferExternalImageExtension(link: string): "jpeg" | "png" | "gif" {
+  const match = /\.([a-zA-Z0-9]{2,5})(?:[?#].*)?$/.exec(link);
+  const ext = match ? match[1].toLowerCase() : "";
+  switch (ext) {
+    case "jpg":
+    case "jpeg":
+      return "jpeg";
+    case "gif":
+      return "gif";
+    case "png":
+    default:
+      return "png";
+  }
+}
+
 // =============================================================================
 // Anchor / Rel Building
 // =============================================================================
 
+/**
+ * Build an image relationship for the given rId, choosing between an embedded
+ * package target (`../media/imageN.ext`) and an external link target
+ * (`TargetMode="External"`) based on whether the image is external.
+ *
+ * Shared by the drawing, background, and watermark write paths so the
+ * embed-vs-link decision lives in exactly one place.
+ */
+export function buildImageRel(rId: string, bookImage: MediaLike): DrawingRel {
+  if (isExternalImage(bookImage)) {
+    return {
+      Id: rId,
+      Type: RelType.Image,
+      Target: bookImage.link as string,
+      TargetMode: "External"
+    };
+  }
+  return {
+    Id: rId,
+    Type: RelType.Image,
+    Target: resolveMediaTarget(bookImage)
+  };
+}
+
 /** Options for {@link buildDrawingAnchorsAndRels}. */
 interface BuildDrawingOptions {
   /** Look up a book-level image by its id. Return `undefined` if not found. */
-  getBookImage: (imageId: string | number) => { name?: string; extension?: string } | undefined;
+  getBookImage: (imageId: string | number) => MediaLike | undefined;
 
   /** Generate the next unique rId string for the drawing rels. */
   nextRId: (rels: DrawingRel[]) => string;
@@ -105,21 +183,21 @@ export function buildDrawingAnchorsAndRels(
       continue;
     }
 
+    // An external (linked) image has a `link` target and no embedded bytes.
+    const isExternal = isExternalImage(bookImage);
+
     // Deduplicate: reuse rId if same imageId already has a drawing rel
     let rIdImage = imageRIdMap[imageId];
     if (!rIdImage) {
       rIdImage = options.nextRId(rels);
       imageRIdMap[imageId] = rIdImage;
-      rels.push({
-        Id: rIdImage,
-        Type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
-        Target: resolveMediaTarget(bookImage)
-      });
+      rels.push(buildImageRel(rIdImage, bookImage));
     }
 
     const anchor: DrawingAnchor = {
       picture: {
-        rId: rIdImage
+        rId: rIdImage,
+        ...(isExternal ? { external: true } : {})
       },
       range: medium.range
     };

--- a/src/modules/excel/workbook.browser.ts
+++ b/src/modules/excel/workbook.browser.ts
@@ -79,6 +79,8 @@ export interface WorkbookMedia {
   buffer?: ExcelBuffer | Uint8Array;
   base64?: string;
   name?: string;
+  /** External link target — when set, the image is referenced, not embedded. */
+  link?: string;
 }
 
 /** Internal model type for serialization */
@@ -2392,7 +2394,42 @@ class Workbook {
   // ===========================================================================
 
   /**
-   * Add Image to Workbook and return the id
+   * Register an image with the workbook and return its numeric id. Pass the id
+   * to {@link Worksheet.addImage}, {@link Worksheet.addBackgroundImage}, or
+   * {@link Worksheet.addWatermark} to place it.
+   *
+   * The image is either **embedded** or **linked (external)**:
+   *
+   * - **Embedded** — supply `buffer`, `base64`, or `filename`. The bytes are
+   *   written into the `.xlsx` package (`xl/media/imageN.ext`). Self-contained,
+   *   but inflates file size.
+   * - **Linked (external)** — supply only `link` (a URL or local file path).
+   *   No bytes are stored; the package keeps a relationship with
+   *   `TargetMode="External"` and the picture is rendered via `<a:blip r:link>`.
+   *   Keeps the file small, but the image is resolved by Excel at open time.
+   *
+   * If both bytes and a `link` are provided, **embedding wins**.
+   *
+   * Linked images work with **cell pictures** ({@link Worksheet.addImage}) and
+   * **overlay watermarks** ({@link Worksheet.addWatermark} with `mode:
+   * "overlay"`). Worksheet background images and header/footer (VML) watermarks
+   * cannot be linked — they require an embedded image.
+   *
+   * Note: Excel treats linked images as volatile — a moved/missing target
+   * shows a broken-image placeholder, and modern Excel may not auto-load
+   * remote URLs for security reasons. Prefer embedding for self-contained files.
+   *
+   * @example Embedded image
+   * ```typescript
+   * const id = workbook.addImage({ buffer: pngBytes, extension: "png" });
+   * worksheet.addImage(id, "B2:D6");
+   * ```
+   *
+   * @example Linked (external) image — no bytes stored
+   * ```typescript
+   * const id = workbook.addImage({ extension: "png", link: "https://example.com/logo.png" });
+   * worksheet.addImage(id, "B2:D6");
+   * ```
    */
   addImage(image: ImageData): number {
     const id = this.media.length;

--- a/src/modules/excel/worksheet.ts
+++ b/src/modules/excel/worksheet.ts
@@ -28,7 +28,7 @@ import type {
 import { Column, type ColumnModel, type ColumnDefn } from "@excel/column";
 import { DataValidations } from "@excel/data-validations";
 import { Enums } from "@excel/enums";
-import { MergeConflictError, TableError } from "@excel/errors";
+import { ImageError, MergeConflictError, TableError } from "@excel/errors";
 import {
   FormCheckbox,
   type FormCheckboxModel,
@@ -65,6 +65,7 @@ import { decodeCell, decodeRange, encodeCol, type Origin } from "@excel/utils/ad
 import { getCellDisplayText } from "@excel/utils/cell-format";
 import { colCache, type DecodedRange } from "@excel/utils/col-cache";
 import { copyStyle } from "@excel/utils/copy-style";
+import { isExternalImage } from "@excel/utils/drawing-utils";
 import { applyMergeBorders, collectMergeBorders } from "@excel/utils/merge-borders";
 import { buildSheetProtection } from "@excel/utils/sheet-protection";
 import {
@@ -1764,9 +1765,22 @@ class Worksheet {
   }
 
   /**
-   * Using the image id from `Workbook.addImage`, set the background to the worksheet
+   * Using the image id from `Workbook.addImage`, set the background to the worksheet.
+   *
+   * The image must be **embedded** (`buffer`/`base64`/`filename`). Worksheet
+   * background pictures (`<picture r:id>`) do not support external (linked)
+   * images — Excel silently drops a background whose relationship uses
+   * `TargetMode="External"`, so this rejects linked images up front.
    */
   addBackgroundImage(imageId: string | number): void {
+    const bookImage = this._workbook.getImage(imageId);
+    if (bookImage && isExternalImage(bookImage)) {
+      throw new ImageError(
+        "Background images cannot be external (linked) images. " +
+          "Use an embedded image (buffer/base64/filename). " +
+          "External images are only supported for cell pictures and overlay watermarks."
+      );
+    }
     const model = {
       type: "background",
       imageId: String(imageId)
@@ -1794,7 +1808,14 @@ class Worksheet {
    *   Visible in Page Layout view and when printed. Renders behind cell content.
    *   Transparency must be baked into the image (PNG with alpha channel).
    *
+   * **External (linked) images:** `mode: "overlay"` supports external images
+   * (registered via `workbook.addImage({ link })`). `mode: "header"` does
+   * **not** — VML header/footer images require embedded media, so passing a
+   * linked image with `mode: "header"` throws an `ImageError`. Use an embedded
+   * image (`buffer`/`base64`/`filename`) or switch to `mode: "overlay"`.
+   *
    * @param options - Watermark configuration
+   * @throws {ImageError} If `mode: "header"` is used with an external (linked) image.
    *
    * @example Overlay watermark with transparency:
    * ```typescript
@@ -1809,12 +1830,28 @@ class Worksheet {
    * ```
    */
   addWatermark(options: WatermarkOptions): void {
+    const mode = options.mode ?? "overlay";
+
+    // Validate BEFORE mutating any state: VML header/footer images use
+    // embedded media (`<v:imagedata o:relid>`); external (linked) images are
+    // not representable here. Reject them up front so a failed call leaves the
+    // existing watermark untouched (no partial mutation).
+    if (mode === "header") {
+      const bookImage = this._workbook.getImage(options.imageId);
+      if (bookImage && isExternalImage(bookImage)) {
+        throw new ImageError(
+          "Header watermark images cannot be external (linked) images. " +
+            "Use an embedded image (buffer/base64/filename), or use overlay mode for linked images."
+        );
+      }
+    }
+
     // Remove any existing watermark media entries first
     this._media = this._media.filter(m => m.type !== "watermark" && m.type !== "headerImage");
 
     this._watermark = {
       imageId: String(options.imageId),
-      mode: options.mode ?? "overlay",
+      mode,
       opacity: options.opacity,
       headerWidth: options.headerWidth,
       headerHeight: options.headerHeight,
@@ -1830,7 +1867,7 @@ class Worksheet {
       };
       this._media.push(new Image(this, model as any));
     } else {
-      // Header mode: add as a "headerImage" media entry for the VML pipeline
+      // Header mode: add as a "headerImage" media entry for the VML pipeline.
       const model = {
         type: "headerImage",
         imageId: String(options.imageId),

--- a/src/modules/excel/xlsx/xform/core/content-types-xform.ts
+++ b/src/modules/excel/xlsx/xform/core/content-types-xform.ts
@@ -1,3 +1,4 @@
+import { isExternalImage } from "@excel/utils/drawing-utils";
 import {
   OOXML_PATHS,
   chartsheetPath,
@@ -33,6 +34,11 @@ class ContentTypesXform extends BaseXform {
     const mediaHash: { [key: string]: boolean } = {};
     (model.media ?? []).forEach((medium: any) => {
       if (medium.type === "image") {
+        // External (linked) images add no part to the package, so they need
+        // no Default content-type registration.
+        if (isExternalImage(medium)) {
+          return;
+        }
         const imageType = medium.extension;
         if (!mediaHash[imageType]) {
           mediaHash[imageType] = true;

--- a/src/modules/excel/xlsx/xform/drawing/base-cell-anchor-xform.ts
+++ b/src/modules/excel/xlsx/xform/drawing/base-cell-anchor-xform.ts
@@ -1,3 +1,4 @@
+import { inferExternalImageExtension } from "@excel/utils/drawing-utils";
 import { BaseXform } from "@excel/xlsx/xform/base-xform";
 
 abstract class BaseCellAnchorXform extends BaseXform {
@@ -43,6 +44,15 @@ abstract class BaseCellAnchorXform extends BaseXform {
       if (!rel) {
         return undefined;
       }
+
+      // External (linked) image: the relationship uses TargetMode="External"
+      // and there is no media part in the package. Synthesize a media entry
+      // carrying the `link` target so it round-trips and surfaces on the
+      // worksheet as an external image. Entries are deduplicated by link.
+      if (rel.TargetMode === "External" || model.external) {
+        return this.reconcileExternalPicture(rel.Target, options);
+      }
+
       const match = rel.Target.match(/.*\/media\/(.+[.][a-zA-Z]{3,4})/);
       if (match) {
         const name = match[1];
@@ -56,6 +66,31 @@ abstract class BaseCellAnchorXform extends BaseXform {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Resolve (or create) the media entry for an external linked image. The
+   * synthesized entry is appended to `options.media` and indexed by its link
+   * so repeated references to the same external image share one entry.
+   */
+  private reconcileExternalPicture(link: string, options: any): any {
+    if (!link) {
+      return undefined;
+    }
+    const indexKey = `external:${link}`;
+    let mediaId = options.mediaIndex[indexKey];
+    if (mediaId === undefined) {
+      mediaId = options.media.length;
+      const medium = {
+        type: "image",
+        extension: inferExternalImageExtension(link),
+        link,
+        index: mediaId
+      };
+      options.media.push(medium);
+      options.mediaIndex[indexKey] = mediaId;
+    }
+    return options.media[mediaId];
   }
 }
 

--- a/src/modules/excel/xlsx/xform/drawing/blip-xform.ts
+++ b/src/modules/excel/xlsx/xform/drawing/blip-xform.ts
@@ -4,6 +4,11 @@ interface BlipModel {
   rId: string;
   /** Alpha modulation (opacity) as OOXML percentage (e.g. 15000 = 15%). */
   alphaModFix?: number;
+  /**
+   * When true, the blip references an external linked image via `r:link`
+   * instead of an embedded one via `r:embed`.
+   */
+  external?: boolean;
 }
 
 class BlipXform extends BaseXform<BlipModel> {
@@ -17,11 +22,13 @@ class BlipXform extends BaseXform<BlipModel> {
   }
 
   render(xmlStream: any, model: BlipModel): void {
+    // External (linked) images use `r:link`; embedded images use `r:embed`.
+    const relAttr = model.external ? "r:link" : "r:embed";
     if (model.alphaModFix !== undefined && model.alphaModFix < 100000) {
       // Render as open/close node with a:alphaModFix child
       xmlStream.openNode(this.tag, {
         "xmlns:r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
-        "r:embed": model.rId,
+        [relAttr]: model.rId,
         cstate: "print"
       });
       xmlStream.leafNode("a:alphaModFix", { amt: String(model.alphaModFix) });
@@ -29,7 +36,7 @@ class BlipXform extends BaseXform<BlipModel> {
     } else {
       xmlStream.leafNode(this.tag, {
         "xmlns:r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
-        "r:embed": model.rId,
+        [relAttr]: model.rId,
         cstate: "print"
       });
     }
@@ -37,11 +44,16 @@ class BlipXform extends BaseXform<BlipModel> {
 
   parseOpen(node: any): boolean {
     switch (node.name) {
-      case this.tag:
-        this.model = {
-          rId: node.attributes["r:embed"]
-        };
+      case this.tag: {
+        // A blip may carry `r:embed` (embedded) or `r:link` (external linked).
+        const link = node.attributes["r:link"];
+        if (link !== undefined) {
+          this.model = { rId: link, external: true };
+        } else {
+          this.model = { rId: node.attributes["r:embed"] };
+        }
         return true;
+      }
       case "a:alphaModFix":
         if (node.attributes.amt) {
           this.model!.alphaModFix = parseInt(node.attributes.amt, 10);

--- a/src/modules/excel/xlsx/xform/drawing/pic-xform.ts
+++ b/src/modules/excel/xlsx/xform/drawing/pic-xform.ts
@@ -9,6 +9,8 @@ interface PicModel {
   rId?: string;
   /** Alpha modulation for transparency (OOXML percentage, e.g. 15000 = 15%). */
   alphaModFix?: number;
+  /** When true, render the picture as an external linked image (`r:link`). */
+  external?: boolean;
   [key: string]: any;
 }
 
@@ -42,7 +44,8 @@ class PicXform extends BaseXform {
     // Pass alphaModFix through to blipFill → blip
     this.map["xdr:blipFill"].render(xmlStream, {
       rId: model.rId,
-      alphaModFix: model.alphaModFix
+      alphaModFix: model.alphaModFix,
+      external: model.external
     });
     this.map["xdr:spPr"].render(xmlStream, model);
 

--- a/src/modules/excel/xlsx/xform/sheet/worksheet-xform.ts
+++ b/src/modules/excel/xlsx/xform/sheet/worksheet-xform.ts
@@ -1,5 +1,10 @@
 import { colCache } from "@excel/utils/col-cache";
-import { buildDrawingAnchorsAndRels, resolveMediaTarget } from "@excel/utils/drawing-utils";
+import {
+  buildDrawingAnchorsAndRels,
+  buildImageRel,
+  isExternalImage,
+  resolveMediaTarget
+} from "@excel/utils/drawing-utils";
 import {
   chartRelTargetFromDrawing,
   chartExRelTargetFromDrawing,
@@ -454,17 +459,23 @@ class WorkSheetXform extends BaseXform {
       }
     });
 
-    // Handle background images
+    // Handle background images. Background pictures are always embedded —
+    // external (linked) images are rejected in addBackgroundImage because Excel
+    // drops a background whose relationship uses TargetMode="External".
     backgroundMedia.forEach(medium => {
-      const rId = nextRid(rels);
       const bookImage = options.media[medium.imageId];
+      // Guard against an invalid imageId — same as the image/watermark paths.
+      if (!bookImage) {
+        return;
+      }
+      const rId = nextRid(rels);
       rels.push({
         Id: rId,
         Type: RelType.Image,
         Target: resolveMediaTarget(bookImage)
       });
       model.background = { rId };
-      model.image = options.media[medium.imageId];
+      model.image = bookImage;
     });
 
     // Handle embedded images — create drawing model using shared utility
@@ -516,12 +527,9 @@ class WorkSheetXform extends BaseXform {
         if (!bookImage) {
           continue;
         }
+        const isExternal = isExternalImage(bookImage);
         const rIdImage = nextRid(drawing.rels);
-        drawing.rels.push({
-          Id: rIdImage,
-          Type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
-          Target: resolveMediaTarget(bookImage)
-        });
+        drawing.rels.push(buildImageRel(rIdImage, bookImage));
         // Convert opacity (0-1) to OOXML percentage (0-100000), clamped
         const rawOpacity = medium.opacity !== undefined ? medium.opacity : 0.15;
         const clampedOpacity = Math.max(0, Math.min(1, rawOpacity));
@@ -536,7 +544,8 @@ class WorkSheetXform extends BaseXform {
         drawing.anchors.push({
           picture: {
             rId: rIdImage,
-            alphaModFix
+            alphaModFix,
+            ...(isExternal ? { external: true } : {})
           },
           // Cover the full data area with extra margin
           range: {

--- a/src/modules/excel/xlsx/xlsx.browser.ts
+++ b/src/modules/excel/xlsx/xlsx.browser.ts
@@ -28,7 +28,7 @@ import {
   ChartOptionsError
 } from "@excel/errors";
 import type { PivotTable, PivotTableSubtotal, ParsedCacheDefinition } from "@excel/pivot-table";
-import { filterDrawingAnchors } from "@excel/utils/drawing-utils";
+import { filterDrawingAnchors, isExternalImage } from "@excel/utils/drawing-utils";
 import { rewriteExternalRefs } from "@excel/utils/external-link-formula";
 import {
   commentsPath,
@@ -586,6 +586,8 @@ export interface WorkbookMediaLike {
   filename?: string;
   buffer?: Uint8Array;
   base64?: string;
+  /** External link target — when set, the image is referenced, not embedded. */
+  link?: string;
 }
 
 export interface MediaModel {
@@ -5416,6 +5418,13 @@ class XLSX<TWorkbook extends Workbook = Workbook> {
       model.media.map(async (medium: WorkbookMediaLike) => {
         if (medium.type !== "image") {
           throw new ImageError("Unsupported media");
+        }
+
+        // External (linked) images carry only a `link` target — no bytes are
+        // written into the package; the relationship (TargetMode="External")
+        // references the image in place.
+        if (isExternalImage(medium)) {
+          return;
         }
 
         // Preserve legacy behavior: `${undefined}` becomes "undefined" in template strings


### PR DESCRIPTION
## Summary

Closes #170.

Adds support for referencing images **externally** (by URL or local file path) instead of embedding their bytes. Linked images are written as `<a:blip r:link>` with a relationship using `TargetMode="External"` — no bytes are stored in the `.xlsx` package, so the file stays small.

```ts
// URL
const id = workbook.addImage({ extension: "png", link: "https://example.com/logo.png" });
worksheet.addImage(id, "B2:D6");

// Local file
const id2 = workbook.addImage({ extension: "png", link: "file:///C:/images/logo.png" });
worksheet.addImage(id2, "F2:H6");
```

## What's supported

| Placement | External (linked)? |
| --- | --- |
| Cell picture (`ws.addImage`) | ✅ |
| Overlay watermark (`addWatermark({ mode: "overlay" })`) | ✅ |
| Worksheet background (`addBackgroundImage`) | ❌ rejected (Excel drops External backgrounds) |
| Header/footer VML watermark (`addWatermark({ mode: "header" })`) | ❌ rejected (VML needs embedded media) |

Unsupported placements **throw an `ImageError`** up front (before mutating any state) rather than producing a file Excel would silently repair. If both bytes and a `link` are supplied, **embedding wins**.

## Notes / caveats (Excel behaviour, not this library)

- Linked images are volatile — a moved/missing target shows a broken-image placeholder.
- Excel desktop does not auto-download remote URL images by default (security); the user must grant access. Verified on macOS Excel: once granted, both URL and `file://` linked images render correctly.

## Implementation

- `ImageData.link` field; `buildImageRel` chooses embed vs External target in one place (shared by cell-picture and watermark write paths)
- `blip-xform` renders `r:link` for external, `r:embed` for embedded; reader parses both
- `addMedia` (non-streaming + streaming) skips writing bytes for external media
- Content-types skips Default registration for external-only images
- Reader synthesises/dedupes linked media from External rels by link

## Tests / docs

- 17 integration tests (write, read, round-trip, streaming, dedup, hyperlink combo, XML-escaping, extension inference, rejection + no-state-mutation cases)
- Full suite green (`pnpm check`, all excel + full vitest)
- Runnable example `examples/images-external.ts`; docs in README (EN/ZH), `addImage`/`addWatermark` JSDoc, and `FROM_EXCELJS.md`