### PR TITLE
chore: remove release-as pin after 0.0.1 shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,7 @@
   "include-component-in-tag": false,
   "packages": {
     ".": {
-      "release-type": "node",
-      "release-as": "0.0.1"
+      "release-type": "node"
     }
   },
   "plugins": ["sentence-case"],


### PR DESCRIPTION
The initial `documonster@0.0.1` release is published (npm `latest` + tag `v0.0.1` + GitHub release), and the release-please manifest baseline is now `0.0.1`.

This drops the `release-as: "0.0.1"` override from `release-please-config.json` so release-please resumes computing the next version from commit history (e.g. `fix:` → 0.0.2, `feat:` → 0.1.0) instead of repeatedly attempting to re-release `0.0.1` (which fails with `already_exists` on the existing tag/release).

Also note: the 120 leftover excelts-era tags (`v1.0.0`–`v10.2.0`) and their GitHub Releases have been removed; only `v0.0.1` remains.