### PR TITLE
fix(excel): ignore XML filter nodes in FilterColumnXform

### DIFF
--- a/src/modules/excel/xlsx/__tests__/xform/table/filter-column-xform.test.ts
+++ b/src/modules/excel/xlsx/__tests__/xform/table/filter-column-xform.test.ts
@@ -48,6 +48,20 @@ const expectations = [
     },
     tests: ["prepare", "render", "renderIn", "parse"],
     options: { index: 0 }
+  },
+  {
+    title: "with dateGroupItem filter",
+    create() {
+      return new FilterColumnXform();
+    },
+    initialModel: { filterButton: true },
+    preparedModel: { colId: "0", filterButton: true },
+    xml: '<filterColumn colId="0" hiddenButton="0"><filters><dateGroupItem year="2025" month="8" dateTimeGrouping="month"/></filters></filterColumn>',
+    get parsedModel() {
+      return { filterButton: true };
+    },
+    tests: ["parse"],
+    options: { index: 0 }
   }
 ];
 

--- a/src/modules/excel/xlsx/xform/table/filter-column-xform.ts
+++ b/src/modules/excel/xlsx/xform/table/filter-column-xform.ts
@@ -76,7 +76,14 @@ class FilterColumnXform extends BaseXform<FilterColumnModel> {
         };
         return true;
       case "dynamicFilter":
-        // Ignore dynamicFilter nodes - we don't need to preserve them for reading
+      case "dateGroupItem":
+      case "top10":
+      case "colorFilter":
+      case "iconFilter":
+      case "extLst":
+        // ECMA-376 Part 1, Section 18.3.2 (AutoFilter Settings):
+        // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.filtercolumn
+        // Ignore non-value filter criteria nodes on read to prevent XmlParseError on valid XLSX files
         return true;
       default:
         this.parser = this.map[node.name];


### PR DESCRIPTION
## Summary

The Excel parser currently fails when hitting valid filter nodes - I was getting the same issue originally reported here: https://github.com/exceljs/exceljs/issues/2972, but with a different filter type. I added dateGroupItem (which was my issue), but also the other nodes in the spec (https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.filtercolumn).

## Test plan

Added a test for one of the "dateGroupItem" node added - didn't bother adding all of them but happy to, if preferred.

## Checklist

- [x] Tests pass locally
- [x] Code follows project style (ran `npm run lint:fix`)
- [x] Added/updated tests for changes
- [ ] Updated documentation if needed
