### PR TITLE
feat(pdf): embed one font face per style so bold and italic survive

### DIFF
--- a/src/modules/pdf/__tests__/font-faces.test.ts
+++ b/src/modules/pdf/__tests__/font-faces.test.ts
@@ -1,0 +1,427 @@
+import { inflateSync } from "node:zlib";
+
+import { createWorkbook, addWorksheet } from "@excel/core/workbook";
+import { Cell } from "@excel/index";
+import { PdfWriter } from "@pdf/core/pdf-writer";
+import { PdfRenderError } from "@pdf/errors";
+import type { ExcelToPdfOptions } from "@pdf/excel-bridge";
+import { FontManager } from "@pdf/font/font-manager";
+import { parseTtf } from "@pdf/font/ttf-parser";
+/**
+ * Tests for embedding one TrueType face per style, so a document that embeds a
+ * font for its Unicode coverage keeps its bold and italic runs.
+ */
+import { describe, it, expect } from "vitest";
+
+import { buildTtfWithCmap } from "./ttf-test-utils";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/**
+ * A face covering 'A' and 'B', identified by its family name and given a
+ * distinct advance width per face so measurements prove *which* face answered.
+ */
+function buildFace(family: string, advance: number): Uint8Array {
+  return buildTtfWithCmap([{ start: 0x41, end: 0x42, delta: -0x40 }], 3, {
+    advanceWidths: [500, advance, advance],
+    familyName: family,
+    postScriptName: `${family}-Regular`
+  });
+}
+
+const REGULAR = buildFace("FaceRegular", 600);
+const BOLD = buildFace("FaceBold", 700);
+const ITALIC = buildFace("FaceItalic", 800);
+const BOLD_ITALIC = buildFace("FaceBoldItalic", 900);
+
+/** All four faces registered on a fresh manager. */
+function managerWithAllFaces(): FontManager {
+  const fm = new FontManager();
+  fm.registerEmbeddedFontFace(parseTtf(REGULAR), "regular");
+  fm.registerEmbeddedFontFace(parseTtf(BOLD), "bold");
+  fm.registerEmbeddedFontFace(parseTtf(ITALIC), "italic");
+  fm.registerEmbeddedFontFace(parseTtf(BOLD_ITALIC), "boldItalic");
+  return fm;
+}
+
+/**
+ * The advance width one em of 'A' occupies at size 1000 — a stand-in for face
+ * identity, since each fixture face uses a different advance.
+ */
+function faceWidth(fm: FontManager, bold: boolean, italic: boolean): number {
+  return fm.measureText("A", fm.resolveFont("Arial", bold, italic), 1000);
+}
+
+// =============================================================================
+// FontManager — face resolution
+// =============================================================================
+
+describe("FontManager multi-face resolution", () => {
+  it("routes each style to its own face", () => {
+    const fm = managerWithAllFaces();
+
+    expect(faceWidth(fm, false, false)).toBeCloseTo(600, 5);
+    expect(faceWidth(fm, true, false)).toBeCloseTo(700, 5);
+    expect(faceWidth(fm, false, true)).toBeCloseTo(800, 5);
+    expect(faceWidth(fm, true, true)).toBeCloseTo(900, 5);
+  });
+
+  it("gives every style its own PDF resource", () => {
+    const fm = managerWithAllFaces();
+    const names = new Set([
+      fm.resolveFont("Arial", false, false),
+      fm.resolveFont("Arial", true, false),
+      fm.resolveFont("Arial", false, true),
+      fm.resolveFont("Arial", true, true)
+    ]);
+
+    expect(names.size).toBe(4);
+  });
+
+  it("keeps a single registered font on every style — the pre-existing behaviour", () => {
+    const fm = new FontManager();
+    fm.registerEmbeddedFont(parseTtf(REGULAR));
+
+    const regular = fm.resolveFont("Arial", false, false);
+    expect(fm.resolveFont("Arial", true, false)).toBe(regular);
+    expect(fm.resolveFont("Arial", false, true)).toBe(regular);
+    expect(fm.resolveFont("Arial", true, true)).toBe(regular);
+    expect(regular).toBe(fm.getEmbeddedResourceName());
+  });
+
+  it("falls back to regular for styles that were not supplied", () => {
+    const fm = new FontManager();
+    fm.registerEmbeddedFontFace(parseTtf(REGULAR), "regular");
+    fm.registerEmbeddedFontFace(parseTtf(BOLD), "bold");
+
+    // bold has its own face; italic was not supplied, so regular draws it.
+    expect(faceWidth(fm, true, false)).toBeCloseTo(700, 5);
+    expect(faceWidth(fm, false, true)).toBeCloseTo(600, 5);
+  });
+
+  it("prefers bold over italic for bold+italic when boldItalic is missing", () => {
+    const fm = new FontManager();
+    fm.registerEmbeddedFontFace(parseTtf(REGULAR), "regular");
+    fm.registerEmbeddedFontFace(parseTtf(BOLD), "bold");
+    fm.registerEmbeddedFontFace(parseTtf(ITALIC), "italic");
+
+    expect(faceWidth(fm, true, true)).toBeCloseTo(700, 5);
+  });
+
+  it("uses italic for bold+italic when only italic is supplied", () => {
+    const fm = new FontManager();
+    fm.registerEmbeddedFontFace(parseTtf(REGULAR), "regular");
+    fm.registerEmbeddedFontFace(parseTtf(ITALIC), "italic");
+
+    expect(faceWidth(fm, true, true)).toBeCloseTo(800, 5);
+  });
+
+  it("replaces a style when it is registered twice", () => {
+    const fm = new FontManager();
+    fm.registerEmbeddedFontFace(parseTtf(REGULAR), "regular");
+    const first = fm.registerEmbeddedFontFace(parseTtf(BOLD), "bold");
+    const second = fm.registerEmbeddedFontFace(parseTtf(BOLD_ITALIC), "bold");
+
+    expect(second).not.toBe(first);
+    expect(fm.resolveFont("Arial", true, false)).toBe(second);
+    expect(fm.isEmbeddedFont(first)).toBe(false);
+    expect(faceWidth(fm, true, false)).toBeCloseTo(900, 5);
+  });
+
+  it("reports embedded state and suppresses the Type3 fallback", () => {
+    const fm = managerWithAllFaces();
+
+    expect(fm.hasEmbeddedFont()).toBe(true);
+    // 'č' (U+010D) is outside WinAnsi — with faces embedded it is drawn by
+    // one of them rather than by a Type3 fallback glyph.
+    expect(fm.needsType3(0x10d)).toBe(false);
+    expect(fm.isEmbeddedFont(fm.resolveFont("Arial", true, false))).toBe(true);
+  });
+
+  it("defaults to the regular face for the document resource name", () => {
+    const fm = managerWithAllFaces();
+
+    expect(fm.getEmbeddedResourceName()).toBe(fm.resolveFont("Arial", false, false));
+  });
+});
+
+// =============================================================================
+// FontManager — per-face metrics, deferred routing, encoding
+// =============================================================================
+
+describe("FontManager multi-face metrics and encoding", () => {
+  it("measures each face with its own advance widths", () => {
+    const fm = managerWithAllFaces();
+    const regular = fm.resolveFont("Arial", false, false);
+    const bold = fm.resolveFont("Arial", true, false);
+
+    // 'AB' = 2 glyphs, at size 10: regular 2*600/1000*10, bold 2*700/1000*10
+    expect(fm.measureText("AB", regular, 10)).toBeCloseTo(12, 5);
+    expect(fm.measureText("AB", bold, 10)).toBeCloseTo(14, 5);
+  });
+
+  it("reports per-face vertical metrics", () => {
+    const fm = managerWithAllFaces();
+    const bold = fm.resolveFont("Arial", true, false);
+
+    // The fixture faces share ascent 800 / descent -200 over 1000 units.
+    expect(fm.getFontAscent(bold, 10)).toBeCloseTo(8, 5);
+    expect(fm.getFontDescent(bold, 10)).toBeCloseTo(-2, 5);
+    expect(fm.getLineHeight(bold, 10)).toBeCloseTo(10, 5);
+  });
+
+  it("routes a deferred Type1 resource to the face matching its style", () => {
+    const fm = managerWithAllFaces();
+    const type1Bold = fm.ensureFont("Helvetica-Bold");
+    const type1Italic = fm.ensureFont("Times-Italic");
+    const type1BoldItalic = fm.ensureFont("Helvetica-BoldOblique");
+    const type1Plain = fm.ensureFont("Times-Roman");
+
+    expect(fm.resolveRenderResourceName(type1Bold)).toBe(fm.resolveFont("Arial", true, false));
+    expect(fm.resolveRenderResourceName(type1Italic)).toBe(fm.resolveFont("Arial", false, true));
+    expect(fm.resolveRenderResourceName(type1BoldItalic)).toBe(fm.resolveFont("Arial", true, true));
+    expect(fm.resolveRenderResourceName(type1Plain)).toBe(fm.resolveFont("Arial", false, false));
+  });
+
+  it("leaves a resource that is already a face untouched", () => {
+    const fm = managerWithAllFaces();
+    const bold = fm.resolveFont("Arial", true, false);
+
+    expect(fm.resolveRenderResourceName(bold)).toBe(bold);
+  });
+
+  it("gives each face its own subset CID mapping", async () => {
+    const fm = managerWithAllFaces();
+    fm.trackText("AB");
+
+    const writer = new PdfWriter();
+    await fm.writeFontResources(writer);
+
+    // Every face subsets the same code points, so each encodes 'AB' through
+    // its own map — and each map has to exist.
+    for (const [bold, italic] of [
+      [false, false],
+      [true, false],
+      [false, true],
+      [true, true]
+    ] as const) {
+      const resourceName = fm.resolveFont("Arial", bold, italic);
+      expect(fm.encodeText("AB", resourceName)).toBe("<00010002>");
+    }
+  });
+
+  it("returns null when encoding against a non-embedded resource", async () => {
+    const fm = managerWithAllFaces();
+    fm.trackText("AB");
+    const writer = new PdfWriter();
+    await fm.writeFontResources(writer);
+
+    expect(fm.encodeText("AB", fm.ensureFont("Helvetica"))).toBeNull();
+  });
+});
+
+// =============================================================================
+// PDF inspection helpers
+// =============================================================================
+
+/**
+ * The PDF's content operators as text.
+ *
+ * Content streams are Flate-compressed once they grow past a few operators, so
+ * a document large enough to carry several styles has to be inflated before its
+ * `Tf` / `Tj` operators can be read. Streams that are not Flate — font files,
+ * anything already raw — simply fail to inflate and are skipped.
+ */
+function inflateContent(pdf: Uint8Array): string {
+  const raw = Buffer.from(pdf);
+  const parts: string[] = [];
+  let index = 0;
+  for (;;) {
+    const open = raw.indexOf("stream", index);
+    if (open < 0) {
+      break;
+    }
+    const close = raw.indexOf("endstream", open);
+    if (close < 0) {
+      break;
+    }
+    // Skip the EOL after `stream` — CRLF or LF — and the one before `endstream`.
+    let start = open + "stream".length;
+    if (raw[start] === 0x0d) {
+      start++;
+    }
+    if (raw[start] === 0x0a) {
+      start++;
+    }
+    try {
+      parts.push(inflateSync(raw.subarray(start, close)).toString("latin1"));
+    } catch {
+      // Not a Flate stream — nothing to read here.
+    }
+    // Past the whole keyword — "endstream" itself contains "stream".
+    index = close + "endstream".length;
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Map each font resource name in the PDF to the BaseFont it resolves to, by
+ * following the page Resources entry to the font object it references.
+ */
+function baseFontByResource(pdf: string): Map<string, string> {
+  const objectNumbers = new Map<string, string>();
+  for (const [, resourceName, objNum] of pdf.matchAll(/\/(EF\d+|F\d+)\s+(\d+)\s+0\s+R/g)) {
+    objectNumbers.set(resourceName, objNum);
+  }
+
+  const result = new Map<string, string>();
+  for (const [resourceName, objNum] of objectNumbers) {
+    const start = pdf.indexOf(`\n${objNum} 0 obj`);
+    if (start < 0) {
+      continue;
+    }
+    const body = pdf.slice(start, pdf.indexOf("endobj", start));
+    const baseFont = /\/BaseFont\s*\/(\S+?)[\s/>]/.exec(body);
+    if (baseFont) {
+      result.set(resourceName, baseFont[1]);
+    }
+  }
+  return result;
+}
+
+/**
+ * The PDF's bytes as text. latin1, not utf-8: the file interleaves ASCII syntax
+ * with binary font data, and a 1:1 byte mapping keeps both intact.
+ */
+function pdfText(pdf: Uint8Array): string {
+  return Buffer.from(pdf).toString("latin1");
+}
+
+/**
+ * The BaseFont behind every text-showing operation, in content-stream order.
+ * A `Tf` selects a font resource and every following `Tj` draws with it.
+ */
+function drawnBaseFonts(pdf: Uint8Array): string[] {
+  const resources = baseFontByResource(pdfText(pdf));
+  const content = inflateContent(pdf);
+  const drawn: string[] = [];
+  let current = "";
+  for (const [, selected] of content.matchAll(
+    /\/(EF\d+|F\d+) [\d.]+ Tf|(?:<[0-9A-F]*>|\(.*?\)) Tj/g
+  )) {
+    if (selected) {
+      current = resources.get(selected) ?? selected;
+    } else if (current) {
+      drawn.push(current);
+    }
+  }
+  return drawn;
+}
+
+// =============================================================================
+// Integration — excelToPdf with the `fonts` option
+// =============================================================================
+
+describe("excelToPdf with per-style font faces", () => {
+  async function exportWith(options: ExcelToPdfOptions): Promise<Uint8Array> {
+    const { excelToPdf } = await import("@pdf/excel-bridge");
+
+    const wb = createWorkbook();
+    const ws = addWorksheet(wb, "Test");
+    Cell.setValue(ws, "A1", "AB");
+    Cell.setStyle(ws, "A1", { font: { bold: true } });
+    Cell.setValue(ws, "A2", "AB");
+    Cell.setStyle(ws, "A2", { font: { italic: true } });
+    Cell.setValue(ws, "A3", "AB");
+
+    return excelToPdf(wb, options);
+  }
+
+  it("embeds one subset per supplied face", async () => {
+    const text = pdfText(
+      await exportWith({
+        fonts: { regular: REGULAR, bold: BOLD, italic: ITALIC, boldItalic: BOLD_ITALIC }
+      })
+    );
+
+    expect(text).toContain("%PDF-2.0");
+    expect(text).toContain("FaceRegular-Regular-Subset");
+    expect(text).toContain("FaceBold-Regular-Subset");
+    expect(text).toContain("FaceItalic-Regular-Subset");
+    expect(text).toContain("FaceBoldItalic-Regular-Subset");
+  });
+
+  it("draws each run with the face matching its style", async () => {
+    const drawn = new Set(
+      drawnBaseFonts(
+        await exportWith({
+          fonts: { regular: REGULAR, bold: BOLD, italic: ITALIC, boldItalic: BOLD_ITALIC }
+        })
+      )
+    );
+
+    // The sheet holds a bold cell, an italic cell and a plain cell, so all
+    // three faces have to appear. Before per-style embedding every run drew
+    // with the one embedded font.
+    expect(drawn).toContain("FaceBold-Regular-Subset");
+    expect(drawn).toContain("FaceItalic-Regular-Subset");
+    expect(drawn).toContain("FaceRegular-Regular-Subset");
+  });
+
+  it("draws every run with the one face when a single font is given", async () => {
+    const drawn = new Set(drawnBaseFonts(await exportWith({ font: REGULAR })));
+
+    expect(drawn).toEqual(new Set(["FaceRegular-Regular-Subset"]));
+  });
+
+  it("draws bold runs with the regular face when no bold face was supplied", async () => {
+    const drawn = new Set(
+      drawnBaseFonts(await exportWith({ fonts: { regular: REGULAR, italic: ITALIC } }))
+    );
+
+    expect(drawn).toContain("FaceItalic-Regular-Subset");
+    expect(drawn).toContain("FaceRegular-Regular-Subset");
+    expect(drawn).not.toContain("FaceBold-Regular-Subset");
+  });
+
+  it("embeds only the faces that were supplied", async () => {
+    const text = pdfText(await exportWith({ fonts: { regular: REGULAR, bold: BOLD } }));
+
+    expect(text).toContain("FaceRegular-Regular-Subset");
+    expect(text).toContain("FaceBold-Regular-Subset");
+    expect(text).not.toContain("FaceItalic-Regular-Subset");
+    expect(text).not.toContain("FaceBoldItalic-Regular-Subset");
+  });
+
+  it("takes precedence over the single-font option", async () => {
+    const text = pdfText(await exportWith({ font: BOLD_ITALIC, fonts: { regular: REGULAR } }));
+
+    expect(text).toContain("FaceRegular-Regular-Subset");
+    expect(text).not.toContain("FaceBoldItalic-Regular-Subset");
+  });
+
+  it("throws when the regular face cannot be parsed", async () => {
+    await expect(exportWith({ fonts: { regular: new Uint8Array([1, 2, 3, 4]) } })).rejects.toThrow(
+      PdfRenderError
+    );
+  });
+
+  it("skips an optional face that cannot be parsed", async () => {
+    const text = pdfText(
+      await exportWith({ fonts: { regular: REGULAR, bold: new Uint8Array([1, 2, 3, 4]) } })
+    );
+
+    // The document still renders, drawing bold runs with the regular face.
+    expect(text).toContain("%PDF-2.0");
+    expect(text).toContain("FaceRegular-Regular-Subset");
+  });
+
+  it("still embeds a single face for the `font` option", async () => {
+    const text = pdfText(await exportWith({ font: REGULAR }));
+
+    expect(text).toContain("FaceRegular-Regular-Subset");
+    expect(text).not.toContain("FaceBold-Regular-Subset");
+  });
+});

--- a/src/modules/pdf/font/font-manager.ts
+++ b/src/modules/pdf/font/font-manager.ts
@@ -9,7 +9,15 @@
  * 3. **Type3 fallback fonts** — auto-generated vector-drawn glyphs for
  *    Unicode characters outside WinAnsi when no embedded font is provided.
  *
- * When an embedded font is registered, ALL text uses the embedded font.
+ * Embedded fonts are held as a set of *faces* keyed by style — regular, bold,
+ * italic, boldItalic. Registering a single font (`registerEmbeddedFont`) is the
+ * degenerate case: it registers one `regular` face, and every style resolves
+ * back to it. When several faces are registered, a run's bold/italic selects
+ * the matching face, falling back through boldItalic → bold → italic → regular
+ * for any face the caller did not supply. This is what lets a document embed a
+ * font for its Unicode coverage without giving up bold and italic.
+ *
+ * When any embedded face is registered, ALL text uses an embedded face.
  * When no embedded font is provided, the system uses Type1 for WinAnsi
  * characters and Type3 for everything else.
  *
@@ -122,6 +130,67 @@ export function resolvePdfFontName(fontFamily: string, bold: boolean, italic: bo
 }
 
 // =============================================================================
+// Embedded Font Faces
+// =============================================================================
+
+/**
+ * The style slot an embedded TrueType face occupies.
+ */
+export type EmbeddedFontStyle = "regular" | "bold" | "italic" | "boldItalic";
+
+/**
+ * The style slot a `bold`/`italic` pair maps to.
+ */
+function embeddedStyleFor(bold: boolean, italic: boolean): EmbeddedFontStyle {
+  if (bold && italic) {
+    return "boldItalic";
+  }
+  if (bold) {
+    return "bold";
+  }
+  if (italic) {
+    return "italic";
+  }
+  return "regular";
+}
+
+/**
+ * Recover the style from a resolved standard font name — the inverse of
+ * {@link resolvePdfFontName}. Used when a run was drawn against a Type1
+ * resource and an embedded face has to be chosen for it afterwards.
+ */
+function parsePdfFontStyle(pdfFontName: string): { bold: boolean; italic: boolean } {
+  const suffix = pdfFontName.slice(pdfFontName.indexOf("-") + 1).toLowerCase();
+  return {
+    bold: suffix.includes("bold"),
+    italic: suffix.includes("italic") || suffix.includes("oblique")
+  };
+}
+
+/**
+ * The faces to try, in order, for a requested style. A caller may supply any
+ * subset of the four; the chain degrades to the closest face they did supply
+ * and always terminates at `regular`, which is mandatory.
+ */
+const FACE_FALLBACK: Record<EmbeddedFontStyle, readonly EmbeddedFontStyle[]> = {
+  regular: ["regular"],
+  bold: ["bold", "regular"],
+  italic: ["italic", "regular"],
+  boldItalic: ["boldItalic", "bold", "italic", "regular"]
+};
+
+/**
+ * One registered embedded TrueType face. `result` is filled in by
+ * `writeFontResources`, which subsets the face and produces its CID mapping.
+ */
+interface EmbeddedFace {
+  style: EmbeddedFontStyle;
+  font: TtfFont;
+  resourceName: string;
+  result: EmbeddedFont | null;
+}
+
+// =============================================================================
 // Font Manager
 // =============================================================================
 
@@ -137,8 +206,10 @@ export class FontManager {
   private nextType1Id = 1;
 
   // --- Embedded TrueType font tracking ---
-  private embeddedFont: TtfFont | null = null;
-  private embeddedResourceName = "";
+  /** Registered faces, keyed by the style slot they fill. */
+  private faces = new Map<EmbeddedFontStyle, EmbeddedFace>();
+  /** The same faces keyed by PDF resource name, for draw-time lookups. */
+  private facesByResource = new Map<string, EmbeddedFace>();
   private usedCodePoints = new Set<number>();
   private nextEmbeddedId = 1;
 
@@ -164,18 +235,59 @@ export class FontManager {
   /**
    * Register an embedded TrueType font for use.
    * When set, all text rendering uses this font instead of standard fonts.
+   *
+   * Shorthand for registering a single `regular` face: with no other face
+   * present every style resolves back to it, which is the historical
+   * single-font behaviour.
    */
   registerEmbeddedFont(font: TtfFont): string {
-    this.embeddedFont = font;
-    this.embeddedResourceName = `EF${this.nextEmbeddedId++}`;
-    return this.embeddedResourceName;
+    return this.registerEmbeddedFontFace(font, "regular");
+  }
+
+  /**
+   * Register one embedded TrueType face for a single style slot.
+   *
+   * Registering `regular` plus any of `bold` / `italic` / `boldItalic` lets a
+   * run's bold and italic survive embedding — `resolveFont` picks the face
+   * matching the run instead of drawing everything in one face. Styles left
+   * unregistered fall back through {@link FACE_FALLBACK}.
+   *
+   * Re-registering a style replaces it; the superseded resource name is
+   * dropped, so it never reaches the PDF.
+   */
+  registerEmbeddedFontFace(font: TtfFont, style: EmbeddedFontStyle): string {
+    const previous = this.faces.get(style);
+    if (previous) {
+      this.facesByResource.delete(previous.resourceName);
+    }
+    const resourceName = `EF${this.nextEmbeddedId++}`;
+    const face: EmbeddedFace = { style, font, resourceName, result: null };
+    this.faces.set(style, face);
+    this.facesByResource.set(resourceName, face);
+    return resourceName;
   }
 
   /**
    * Check if an embedded font is available.
    */
   hasEmbeddedFont(): boolean {
-    return this.embeddedFont !== null;
+    return this.faces.size > 0;
+  }
+
+  /**
+   * The face that should draw a run with the given style, or null when no
+   * embedded face is registered at all.
+   */
+  private resolveFace(bold: boolean, italic: boolean): EmbeddedFace | null {
+    for (const style of FACE_FALLBACK[embeddedStyleFor(bold, italic)]) {
+      const face = this.faces.get(style);
+      if (face) {
+        return face;
+      }
+    }
+    // No `regular` face — possible only if a caller registered, say, `bold`
+    // alone. Any face is a better answer than none.
+    return this.faces.values().next().value ?? null;
   }
 
   /**
@@ -202,9 +314,13 @@ export class FontManager {
 
   /**
    * Get the embedded font's resource name (if registered).
+   *
+   * This is the document's *default* face — `regular`, or the closest thing to
+   * it. Style-aware callers should use `resolveFont`, which honours a run's
+   * bold and italic instead of collapsing every run onto this one face.
    */
   getEmbeddedResourceName(): string {
-    return this.embeddedResourceName;
+    return this.resolveFace(false, false)?.resourceName ?? "";
   }
 
   /**
@@ -219,9 +335,18 @@ export class FontManager {
    * Centralises the routing rule shared by the deferred text renderer and
    * any deferred measurement (anchor alignment, word wrapping) so the two
    * never disagree.
+   *
+   * The standard font name behind the Type1 resource still carries the run's
+   * style ("Helvetica-BoldOblique", "Times-Italic", …), so the switch lands on
+   * the face matching that style rather than flattening the run onto the
+   * default face.
    */
   resolveRenderResourceName(type1ResourceName: string): string {
-    return this.embeddedFont ? this.embeddedResourceName : type1ResourceName;
+    if (this.faces.size === 0 || this.facesByResource.has(type1ResourceName)) {
+      return type1ResourceName;
+    }
+    const { bold, italic } = parsePdfFontStyle(this.getPdfFontName(type1ResourceName));
+    return this.resolveFace(bold, italic)?.resourceName ?? type1ResourceName;
   }
 
   /**
@@ -272,12 +397,14 @@ export class FontManager {
 
   /**
    * Resolve an Excel font specification to a resource name.
-   * If an embedded font is registered, returns the embedded font's resource name.
+   * If embedded faces are registered, returns the face matching `bold`/`italic`
+   * (the family is ignored — embedding replaces the typeface, not the style).
    * Otherwise, falls back to standard Type1 fonts.
    */
   resolveFont(fontFamily: string, bold: boolean, italic: boolean): string {
-    if (this.embeddedFont) {
-      return this.embeddedResourceName;
+    const face = this.resolveFace(bold, italic);
+    if (face) {
+      return face.resourceName;
     }
     // Record unknown families so writers can emit a single diagnostic
     // at build time instead of spamming one warning per text run.
@@ -325,7 +452,7 @@ export class FontManager {
    * Check if a code point needs Type3 rendering (non-WinAnsi, no embedded font).
    */
   needsType3(codePoint: number): boolean {
-    return !this.embeddedFont && !isWinAnsiCodePoint(codePoint);
+    return this.faces.size === 0 && !isWinAnsiCodePoint(codePoint);
   }
 
   // ==========================================================================
@@ -337,8 +464,9 @@ export class FontManager {
    * For mixed Type1/Type3 text, measures each character with the right font.
    */
   measureText(text: string, resourceName: string, fontSize: number): number {
-    if (this.embeddedFont && resourceName === this.embeddedResourceName) {
-      return measureEmbeddedText(text, this.embeddedFont, fontSize);
+    const face = this.facesByResource.get(resourceName);
+    if (face) {
+      return measureEmbeddedText(text, face.font, fontSize);
     }
 
     // If no Type3 fonts or text has no non-WinAnsi chars, use Type1 directly
@@ -377,8 +505,9 @@ export class FontManager {
    * Get the font ascent in points.
    */
   getFontAscent(resourceName: string, fontSize: number): number {
-    if (this.embeddedFont && resourceName === this.embeddedResourceName) {
-      return (this.embeddedFont.ascent / this.embeddedFont.unitsPerEm) * fontSize;
+    const face = this.facesByResource.get(resourceName);
+    if (face) {
+      return (face.font.ascent / face.font.unitsPerEm) * fontSize;
     }
     // Type3 fonts use the same metrics as the base Type1 font
     const base = this.isType3Resource(resourceName)
@@ -391,8 +520,9 @@ export class FontManager {
    * Get the font descent in points (negative value).
    */
   getFontDescent(resourceName: string, fontSize: number): number {
-    if (this.embeddedFont && resourceName === this.embeddedResourceName) {
-      return (this.embeddedFont.descent / this.embeddedFont.unitsPerEm) * fontSize;
+    const face = this.facesByResource.get(resourceName);
+    if (face) {
+      return (face.font.descent / face.font.unitsPerEm) * fontSize;
     }
     const base = this.isType3Resource(resourceName)
       ? "Helvetica"
@@ -404,8 +534,9 @@ export class FontManager {
    * Get the line height in points.
    */
   getLineHeight(resourceName: string, fontSize: number): number {
-    if (this.embeddedFont && resourceName === this.embeddedResourceName) {
-      const f = this.embeddedFont;
+    const face = this.facesByResource.get(resourceName);
+    if (face) {
+      const f = face.font;
       return ((f.ascent - f.descent) / f.unitsPerEm) * fontSize;
     }
     const base = this.isType3Resource(resourceName)
@@ -422,7 +553,7 @@ export class FontManager {
    * Check if a resource name refers to an embedded font.
    */
   isEmbeddedFont(resourceName: string): boolean {
-    return this.embeddedFont !== null && resourceName === this.embeddedResourceName;
+    return this.facesByResource.has(resourceName);
   }
 
   /**
@@ -441,14 +572,15 @@ export class FontManager {
    * subset and produces the unicodeToCid mapping.
    */
   encodeText(text: string, resourceName: string): string | null {
-    if (!this.embeddedFont || resourceName !== this.embeddedResourceName) {
+    const face = this.facesByResource.get(resourceName);
+    if (!face) {
       return null;
     }
 
     // After writeFontResources, use the subset's CID mapping
     // (maps Unicode code points → new sequential glyph IDs in the subset font)
-    if (this._embeddedResult) {
-      return encodeWithCidMap(text, this._embeddedResult.unicodeToCid);
+    if (face.result) {
+      return encodeWithCidMap(text, face.result.unicodeToCid);
     }
 
     // writeFontResources not called yet — this is a programming error
@@ -514,23 +646,25 @@ export class FontManager {
       fontObjectMap.set(resourceName, objNum);
     }
 
-    // Write embedded TrueType font
-    if (this.embeddedFont && this.embeddedResourceName) {
-      const embedded = embedTtfFont(
-        writer,
-        this.embeddedFont,
-        this.usedCodePoints,
-        this.embeddedResourceName
-      );
-      fontObjectMap.set(this.embeddedResourceName, embedded.fontObjNum);
+    // Write embedded TrueType faces — one subset per registered face.
+    //
+    // Every face is subsetted over the same `usedCodePoints`. Code points are
+    // tracked per document, not per run, so there is no way to know which of
+    // them a given face actually draws; covering all of them in each face is
+    // what guarantees a run can switch style without hitting .notdef. Code
+    // points a face has no glyph for are skipped by the embedder, and a
+    // document that registers a single face is unaffected.
+    for (const face of this.faces.values()) {
+      const embedded = embedTtfFont(writer, face.font, this.usedCodePoints, face.resourceName);
+      fontObjectMap.set(face.resourceName, embedded.fontObjNum);
       // Store the embedding result for text re-encoding
-      this._embeddedResult = embedded;
+      face.result = embedded;
     }
 
     // Write Type3 fallback fonts (only when no embedded font). The Type3
     // implementation + Unicode glyph tables are loaded on demand so they stay
     // out of bundles that never render non-WinAnsi characters.
-    if (!this.embeddedFont && this.type3CodePoints.size > 0) {
+    if (this.faces.size === 0 && this.type3CodePoints.size > 0) {
       const { writeType3Fonts } = await import("@pdf/font/type3-font");
       this._type3Result = writeType3Fonts(writer, this.type3CodePoints);
       for (const [resourceName, objNum] of this._type3Result.fontObjects) {
@@ -541,14 +675,12 @@ export class FontManager {
     return fontObjectMap;
   }
 
-  /** Stored after writeFontResources is called */
-  private _embeddedResult: EmbeddedFont | null = null;
-
   /**
-   * Get the embedded font result (available after writeFontResources).
+   * Get the default face's embedding result (available after
+   * writeFontResources).
    */
   getEmbeddedResult(): EmbeddedFont | null {
-    return this._embeddedResult;
+    return this.resolveFace(false, false)?.result ?? null;
   }
 
   /**

--- a/src/modules/pdf/index.ts
+++ b/src/modules/pdf/index.ts
@@ -59,6 +59,7 @@ export type { PdfCell, PdfRow, PdfColumn, PdfSheet, PdfBook, PdfImage, PdfInput 
 
 export type {
   PdfExportOptions,
+  PdfEmbeddedFontFaces,
   PdfOrientation,
   PdfPageOrder,
   PdfCellErrorMode,

--- a/src/modules/pdf/render/chart-surface.ts
+++ b/src/modules/pdf/render/chart-surface.ts
@@ -19,7 +19,6 @@
 
 import type { PdfContentStream } from "@pdf/core/pdf-stream";
 import type { FontManager } from "@pdf/font/font-manager";
-import { resolvePdfFontName } from "@pdf/font/font-manager";
 import { alphaGsName, emitTextBlock } from "@pdf/render/page-renderer";
 import { toGrayscale } from "@pdf/render/style-converter";
 import type { PdfChartDrawingSurface, PdfChartPathOp, PdfColor } from "@pdf/types";
@@ -185,7 +184,7 @@ export function createChartSurface(
       // Type1 style variants exist before the resource dictionary is emitted.
       fontManager.trackText(text);
 
-      const resourceName = resolveResourceName(fontManager, fontFamily, bold, italic);
+      const resourceName = fontManager.resolveFont(fontFamily, bold, italic);
 
       stream.save();
       stream.setFillColor(color);
@@ -254,16 +253,4 @@ export function createChartSurface(
       return this;
     }
   };
-}
-
-function resolveResourceName(
-  fontManager: FontManager,
-  fontFamily: string,
-  bold: boolean,
-  italic: boolean
-): string {
-  if (fontManager.hasEmbeddedFont()) {
-    return fontManager.getEmbeddedResourceName();
-  }
-  return fontManager.ensureFont(resolvePdfFontName(fontFamily, bold, italic));
 }

--- a/src/modules/pdf/render/layout-engine.ts
+++ b/src/modules/pdf/render/layout-engine.ts
@@ -18,7 +18,6 @@
  */
 
 import type { FontManager } from "@pdf/font/font-manager";
-import { resolvePdfFontName } from "@pdf/font/font-manager";
 import {
   CELL_PADDING_H,
   CELL_PADDING_V,
@@ -497,9 +496,7 @@ function computeHeadingMetrics(
   options: ResolvedPdfOptions
 ): LayoutHeadings {
   const fontSize = HEADING_FONT_SIZE;
-  const resourceName = fontManager.hasEmbeddedFont()
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(options.defaultFontFamily, false, false));
+  const resourceName = fontManager.resolveFont(options.defaultFontFamily, false, false);
 
   const lastRow = printRange?.endRow ?? sheet.bounds.bottom;
   const widestLabel = String(Math.max(1, lastRow));
@@ -579,9 +576,7 @@ function buildCommentPages(
   const bottom = margins.bottom + footerHeight;
 
   const fontSize = options.defaultFontSize;
-  const resourceName = fontManager.hasEmbeddedFont()
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(options.defaultFontFamily, false, false));
+  const resourceName = fontManager.resolveFont(options.defaultFontFamily, false, false);
   const measure = (text: string) => fontManager.measureText(text, resourceName, fontSize);
   const lineHeight = fontSize * LINE_HEIGHT_FACTOR;
   const textColor = { r: 0, g: 0, b: 0 };
@@ -1310,10 +1305,11 @@ function countWrapLines(
     options.defaultFontFamily,
     options.defaultFontSize
   );
-  const pdfFontName = resolvePdfFontName(fontProps.fontFamily, fontProps.bold, fontProps.italic);
-  const resourceName = fontManager.hasEmbeddedFont()
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(pdfFontName);
+  const resourceName = fontManager.resolveFont(
+    fontProps.fontFamily,
+    fontProps.bold,
+    fontProps.italic
+  );
   const measure = (s: string) => fontManager.measureText(s, resourceName, fontSize);
   const wrappedLines = wrapTextLines(text, measure, effectiveWidth);
 
@@ -1359,10 +1355,7 @@ function countRichTextWrapLines(
         }
       : cellFont;
     const fontProps = extractFontProperties(effectiveRunFont, defaultFamily, defaultSize);
-    const pdfFontName = resolvePdfFontName(fontProps.fontFamily, fontProps.bold, fontProps.italic);
-    return fontManager.hasEmbeddedFont()
-      ? fontManager.getEmbeddedResourceName()
-      : fontManager.ensureFont(pdfFontName);
+    return fontManager.resolveFont(fontProps.fontFamily, fontProps.bold, fontProps.italic);
   });
 
   // Resolve scaled font sizes for each run
@@ -1692,15 +1685,10 @@ function buildLayoutCell(
   // Scale font size proportionally when fitToPage shrinks the layout
   const scaledFontSize = fontProps.fontSize * scaleFactor;
 
-  // Register font and track text for subsetting
-  if (fontManager.hasEmbeddedFont()) {
-    fontManager.trackText(text);
-  } else {
-    const pdfFontName = resolvePdfFontName(fontProps.fontFamily, fontProps.bold, fontProps.italic);
-    fontManager.ensureFont(pdfFontName);
-    // Track non-WinAnsi code points for Type3 fallback font generation
-    fontManager.trackText(text);
-  }
+  // Register the font this run needs and track its text for subsetting
+  // (non-WinAnsi code points also drive Type3 fallback generation).
+  fontManager.resolveFont(fontProps.fontFamily, fontProps.bold, fontProps.italic);
+  fontManager.trackText(text);
 
   // Rich text runs — pass cell-level font as the fallback for runs without
   // their own font definition (e.g. the first run often has no font object
@@ -2175,17 +2163,12 @@ function computeTextOverflows(
       let textWidth: number;
       if (cell.richText) {
         textWidth = 0;
-        const isEmbedded = fontManager.hasEmbeddedFont();
         for (const run of cell.richText) {
-          const resourceName = isEmbedded
-            ? fontManager.getEmbeddedResourceName()
-            : fontManager.ensureFont(resolvePdfFontName(run.fontFamily, run.bold, run.italic));
+          const resourceName = fontManager.resolveFont(run.fontFamily, run.bold, run.italic);
           textWidth += fontManager.measureText(run.text, resourceName, run.fontSize);
         }
       } else {
-        const resourceName = fontManager.hasEmbeddedFont()
-          ? fontManager.getEmbeddedResourceName()
-          : fontManager.ensureFont(resolvePdfFontName(cell.fontFamily, cell.bold, cell.italic));
+        const resourceName = fontManager.resolveFont(cell.fontFamily, cell.bold, cell.italic);
         textWidth = fontManager.measureText(cell.text, resourceName, cell.fontSize);
       }
 
@@ -2313,16 +2296,12 @@ function buildRichTextRuns(
 
     const fontProps = extractFontProperties(effectiveFont, defaultFamily, defaultSize);
 
-    // Register font for this run
+    // Register the font this run needs. Its text is tracked for subsetting
+    // only when an embedded face will draw it — without one the run renders
+    // through Type1/Type3, whose code points the cell-level pass collects.
+    fontManager.resolveFont(fontProps.fontFamily, fontProps.bold, fontProps.italic);
     if (fontManager.hasEmbeddedFont()) {
       fontManager.trackText(run.text);
-    } else {
-      const pdfFontName = resolvePdfFontName(
-        fontProps.fontFamily,
-        fontProps.bold,
-        fontProps.italic
-      );
-      fontManager.ensureFont(pdfFontName);
     }
 
     return {

--- a/src/modules/pdf/render/page-renderer.ts
+++ b/src/modules/pdf/render/page-renderer.ts
@@ -552,10 +552,7 @@ function drawCellText(
   }
 
   // --- Plain text rendering ---
-  const isEmbedded = fontManager.hasEmbeddedFont();
-  const resourceName = isEmbedded
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(cell.fontFamily, cell.bold, cell.italic));
+  const resourceName = fontManager.resolveFont(cell.fontFamily, cell.bold, cell.italic);
 
   const measure = (s: string) => fontManager.measureText(s, resourceName, fontSize);
   const effectiveWidth = availWidth - indentPts;
@@ -576,7 +573,7 @@ function drawCellText(
 
   stream.setFillColor(cell.textColor);
 
-  const useType3 = fontManager.hasType3Fonts() && !isEmbedded;
+  const useType3 = fontManager.hasType3Fonts() && !fontManager.hasEmbeddedFont();
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -627,13 +624,9 @@ function drawRichText(
   const primaryFontSize = maxFontSize;
   const lineHeight = primaryFontSize * LINE_HEIGHT_FACTOR;
 
-  const isEmbedded = fontManager.hasEmbeddedFont();
-
   // Helper: resolve resource name for a run
   const runResource = (run: LayoutRichTextRun) =>
-    isEmbedded
-      ? fontManager.getEmbeddedResourceName()
-      : fontManager.ensureFont(resolvePdfFontName(run.fontFamily, run.bold, run.italic));
+    fontManager.resolveFont(run.fontFamily, run.bold, run.italic);
 
   // --- Wrapping path ---
   if (wrapText) {
@@ -718,7 +711,7 @@ function drawRichText(
       }
 
       let textX = computeTextX(horizontalAlign, rect, lineWidth, indentPts, pad.left, pad.right);
-      const useType3 = fontManager.hasType3Fonts() && !isEmbedded;
+      const useType3 = fontManager.hasType3Fonts() && !fontManager.hasEmbeddedFont();
       for (const seg of segments) {
         const { run, text, resourceName } = seg;
 
@@ -773,7 +766,7 @@ function drawRichText(
     pad.bottom
   );
   let textX = computeTextX(horizontalAlign, rect, totalWidth, indentPts, pad.left, pad.right);
-  const useType3 = fontManager.hasType3Fonts() && !isEmbedded;
+  const useType3 = fontManager.hasType3Fonts() && !fontManager.hasEmbeddedFont();
 
   for (let i = 0; i < runs.length; i++) {
     const run = runs[i];
@@ -821,10 +814,7 @@ function drawRotatedText(
   const { rect, wrapText } = cell;
   let { fontSize } = cell;
   const pad = computeCellPadding(cell, scaleFactor);
-  const isEmbedded = fontManager.hasEmbeddedFont();
-  const resourceName = isEmbedded
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(cell.fontFamily, cell.bold, cell.italic));
+  const resourceName = fontManager.resolveFont(cell.fontFamily, cell.bold, cell.italic);
 
   // Convert Excel rotation to degrees
   const degrees = excelRotationToDegrees(cell.textRotation);
@@ -1494,10 +1484,7 @@ function drawVerticalStackedText(
 ): void {
   const { rect, text, fontSize, horizontalAlign, verticalAlign } = cell;
   const pad = computeCellPadding(cell, scaleFactor);
-  const isEmbedded = fontManager.hasEmbeddedFont();
-  const resourceName = isEmbedded
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(cell.fontFamily, cell.bold, cell.italic));
+  const resourceName = fontManager.resolveFont(cell.fontFamily, cell.bold, cell.italic);
 
   const charHeight = fontSize * 1.3;
   const ascent = fontManager.getFontAscent(resourceName, fontSize);
@@ -2063,11 +2050,11 @@ function resolveLineRuns(
   width: number;
 }> {
   return line.map(({ run, text }) => {
-    const resourceName = fontManager.hasEmbeddedFont()
-      ? fontManager.getEmbeddedResourceName()
-      : fontManager.ensureFont(
-          resolvePdfFontName(resolveHeaderFooterFontFamily(run, page), run.bold, run.italic)
-        );
+    const resourceName = fontManager.resolveFont(
+      resolveHeaderFooterFontFamily(run, page),
+      run.bold,
+      run.italic
+    );
     const fontSize =
       run.fontSize * (page.headerFooter?.scaleWithDoc === false ? 1 : page.scaleFactor);
     const width = fontManager.measureText(text, resourceName, fontSize);
@@ -2110,9 +2097,7 @@ function drawRowColHeadings(
   }
 
   const { gutterWidth, bandHeight, fontSize } = headings;
-  const resourceName = fontManager.hasEmbeddedFont()
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(options.defaultFontFamily, false, false));
+  const resourceName = fontManager.resolveFont(options.defaultFontFamily, false, false);
 
   // The heading palette is already neutral gray, so black-and-white needs no
   // conversion here.
@@ -2218,9 +2203,7 @@ function drawCommentBoxes(
   const fill = bw ? toGrayscale(COMMENT_FILL) : COMMENT_FILL;
   const border = bw ? toGrayscale(COMMENT_BORDER) : COMMENT_BORDER;
   const markerColor = bw ? toGrayscale(COMMENT_MARKER_COLOR) : COMMENT_MARKER_COLOR;
-  const resourceName = fontManager.hasEmbeddedFont()
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(options.defaultFontFamily, false, false));
+  const resourceName = fontManager.resolveFont(options.defaultFontFamily, false, false);
 
   for (const box of boxes) {
     const { rect } = box;
@@ -2276,9 +2259,7 @@ function drawPageHeader(
 ): void {
   const headerFontSize = 10;
   const headerText = page.sheetName;
-  const resourceName = fontManager.hasEmbeddedFont()
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(options.defaultFontFamily, true, false));
+  const resourceName = fontManager.resolveFont(options.defaultFontFamily, true, false);
 
   const textWidth = fontManager.measureText(headerText, resourceName, headerFontSize);
   const x = (page.width - textWidth) / 2;
@@ -2440,10 +2421,7 @@ function renderTextWatermark(
   const bold = watermark.bold ?? TEXT_WM_DEFAULTS.bold;
   const italic = watermark.italic ?? TEXT_WM_DEFAULTS.italic;
 
-  const isEmbedded = fontManager.hasEmbeddedFont();
-  const resourceName = isEmbedded
-    ? fontManager.getEmbeddedResourceName()
-    : fontManager.ensureFont(resolvePdfFontName(fontFamily, bold, italic));
+  const resourceName = fontManager.resolveFont(fontFamily, bold, italic);
 
   const textWidth = fontManager.measureText(watermark.text, resourceName, fontSize);
   // Approximate text height using ascent (roughly 0.7 * fontSize for most fonts)

--- a/src/modules/pdf/render/pdf-exporter.ts
+++ b/src/modules/pdf/render/pdf-exporter.ts
@@ -31,6 +31,7 @@ import type {
   PdfWorkbook,
   PdfWorkbookSheet,
   PdfExportOptions,
+  PdfEmbeddedFontFaces,
   ResolvedPdfOptions,
   PdfPageSize,
   PdfMargins,
@@ -116,10 +117,18 @@ function prepareExport(workbook: PdfWorkbook, options?: PdfExportOptions): Expor
   // User-provided fonts can be registered immediately. Automatic discovery is
   // delayed until after layout/preflight, when headers, footers, watermarks,
   // and vector charts have all reported their Unicode text.
-  const fontData = options?.font ?? null;
+  //
+  // `fonts` supersedes `font`: it carries one face per style, so bold and
+  // italic survive embedding instead of collapsing onto a single face.
+  const faceData = options?.fonts ?? null;
+  const fontData = faceData ? null : (options?.font ?? null);
 
-  if (!fontData) {
+  if (!fontData && !faceData) {
     registerSystemFontForCodePoints(fontManager, collectNonWinAnsiCodePoints(sheets));
+  }
+
+  if (faceData) {
+    registerEmbeddedFontFaces(fontManager, faceData);
   }
 
   if (fontData) {
@@ -188,9 +197,7 @@ async function finishExport(
     const wmBold = watermark.bold ?? false;
     const wmItalic = watermark.italic ?? false;
     fontManager.trackText(watermark.text);
-    if (!fontManager.hasEmbeddedFont()) {
-      fontManager.ensureFont(resolvePdfFontName(wmFontFamily, wmBold, wmItalic));
-    }
+    fontManager.resolveFont(wmFontFamily, wmBold, wmItalic);
   }
 
   registerAutoDiscoveredFont(fontManager);
@@ -258,6 +265,31 @@ function registerAutoDiscoveredFont(fontManager: FontManager): void {
   registerSystemFontForCodePoints(fontManager, codePoints);
 }
 
+/**
+ * Register the caller's per-style faces.
+ *
+ * `regular` is mandatory and a failure to parse it is fatal, exactly as a bad
+ * `font` is. The optional faces are best-effort: one that fails to parse is
+ * skipped and its style falls back to a face that did parse, which keeps a
+ * single corrupt bold file from failing an otherwise renderable document.
+ */
+function registerEmbeddedFontFaces(fontManager: FontManager, faces: PdfEmbeddedFontFaces): void {
+  const styles = ["regular", "bold", "italic", "boldItalic"] as const;
+  for (const style of styles) {
+    const data = faces[style];
+    if (!data) {
+      continue;
+    }
+    try {
+      fontManager.registerEmbeddedFontFace(parseTtf(data), style);
+    } catch (err) {
+      if (style === "regular") {
+        throw new PdfRenderError("Failed to parse TrueType font", { cause: err });
+      }
+    }
+  }
+}
+
 function registerSystemFontForCodePoints(
   fontManager: FontManager,
   codePoints: ReadonlySet<number>
@@ -320,17 +352,18 @@ function trackFontsForHeaders(allPages: LayoutPage[], fontManager: FontManager):
     }
   }
 
+  // The page footer draws against a Type1 resource unconditionally (page
+  // numbers are ASCII), so its Type1 font must exist before resources are
+  // written even when an embedded face will ultimately render it.
   for (const page of allPages) {
     if (page.options.showPageNumbers) {
       fontManager.ensureFont(resolvePdfFontName(page.options.defaultFontFamily, false, false));
     }
   }
 
-  if (!fontManager.hasEmbeddedFont()) {
-    for (const page of allPages) {
-      if (page.options.showSheetNames) {
-        fontManager.ensureFont(resolvePdfFontName(page.options.defaultFontFamily, true, false));
-      }
+  for (const page of allPages) {
+    if (page.options.showSheetNames) {
+      fontManager.resolveFont(page.options.defaultFontFamily, true, false);
     }
   }
 
@@ -349,15 +382,11 @@ function trackFontsForHeaders(allPages: LayoutPage[], fontManager: FontManager):
           }
           const text = resolveHeaderFooterRunText(run, page);
           fontManager.trackText(text);
-          if (!fontManager.hasEmbeddedFont()) {
-            fontManager.ensureFont(
-              resolvePdfFontName(
-                run.fontFamily || page.options.defaultFontFamily,
-                run.bold,
-                run.italic
-              )
-            );
-          }
+          fontManager.resolveFont(
+            run.fontFamily || page.options.defaultFontFamily,
+            run.bold,
+            run.italic
+          );
         }
       }
     }

--- a/src/modules/pdf/types.ts
+++ b/src/modules/pdf/types.ts
@@ -614,6 +614,24 @@ export interface PdfHeaderFooterOptions {
 }
 
 /**
+ * Raw .ttf bytes for the embedded faces of one typeface, keyed by style.
+ *
+ * Only `regular` is required. A style left out is drawn by the closest face
+ * that was supplied — `boldItalic` prefers `bold`, then `italic` — and every
+ * chain terminates at `regular`.
+ */
+export interface PdfEmbeddedFontFaces {
+  /** The face used for unstyled runs, and the fallback for every other style. */
+  regular: Uint8Array;
+  /** The face used for bold runs. Falls back to `regular`. */
+  bold?: Uint8Array;
+  /** The face used for italic runs. Falls back to `regular`. */
+  italic?: Uint8Array;
+  /** The face used for bold+italic runs. Falls back to `bold`, `italic`, then `regular`. */
+  boldItalic?: Uint8Array;
+}
+
+/**
  * Options for controlling PDF export behavior.
  */
 export interface PdfExportOptions {
@@ -873,8 +891,37 @@ export interface PdfExportOptions {
    * const font = readFileSync("NotoSansSC-Regular.ttf");
    * Pdf.fromExcel(workbook, { font });
    * ```
+   *
+   * A single font draws every run in one face, so bold and italic cell styles
+   * are lost. Use {@link PdfExportOptions.fonts} to embed one face per style.
    */
   font?: Uint8Array;
+
+  /**
+   * TrueType font files (.ttf), one per style, for Unicode text support that
+   * keeps bold and italic.
+   *
+   * A document that embeds a font for its script — Croatian `č`/`ć`/`đ` as
+   * much as CJK — otherwise has to give up styled text, because a single
+   * embedded font draws every run. Supplying the faces separately lets a run's
+   * bold and italic pick the matching one:
+   *
+   * ```typescript
+   * Pdf.fromExcel(workbook, {
+   *   fonts: {
+   *     regular: readFileSync("NotoSans-Regular.ttf"),
+   *     bold: readFileSync("NotoSans-Bold.ttf"),
+   *     italic: readFileSync("NotoSans-Italic.ttf"),
+   *     boldItalic: readFileSync("NotoSans-BoldItalic.ttf")
+   *   }
+   * });
+   * ```
+   *
+   * Only `regular` is required; any style left out falls back to the closest
+   * face that was supplied, ending at `regular`. Takes precedence over
+   * {@link PdfExportOptions.font} when both are given.
+   */
+  fonts?: PdfEmbeddedFontFaces;
 
   /**
    * Encryption options for password-protecting the PDF.


### PR DESCRIPTION
## Summary

`Pdf.fromExcel(workbook, { font })` accepts exactly one embedded TrueType font, and once it is
registered every text run is drawn in it — the `bold` / `italic` flags on the cell styles are dropped.
Any document that needs an embedded font for its script has to give up bold and italic entirely, even
though the faces exist and the caller would happily supply them.

This is not an exotic-script problem. The built-in coverage is WinAnsi plus a Type3 fallback with no
Latin Extended-A, so plain Croatian (`č` U+010D, `ć` U+0107, `đ` U+0111 — `š` and `ž` are in WinAnsi
and survive) already forces an embedded font, and with it the loss of every bold heading in the
document. Czech, Slovak, Polish, Hungarian, Romanian, Turkish and Baltic text are in the same position.

### API

```typescript
Pdf.fromExcel(workbook, {
  fonts: {
    regular: regularBytes,       // required
    bold: boldBytes,             // optional
    italic: italicBytes,         // optional
    boldItalic: boldItalicBytes  // optional
  }
});
```

Only `regular` is required; a style left out falls back through `boldItalic → bold → italic →
regular`. `font` keeps its current single-face meaning — it now registers one `regular` face that
every style resolves back to — so nothing breaks.

### How it works

`FontManager` holds embedded fonts as a set of faces keyed by style instead of one field. The single-
font case is the degenerate one: `registerEmbeddedFont` registers a `regular` face.

The interesting part is that almost nothing else had to change. `resolveFont(family, bold, italic)`
already had exactly the right contract — it just discarded the style whenever a font was embedded:

```ts
resolveFont(fontFamily, bold, italic) {
  if (this.embeddedFont) {
    return this.embeddedResourceName;   // style dropped here
  }
  …
}
```

Fixing it at that one point let 15 call sites across `page-renderer.ts`, `layout-engine.ts` and
`chart-surface.ts` collapse from

```ts
fontManager.hasEmbeddedFont()
  ? fontManager.getEmbeddedResourceName()
  : fontManager.ensureFont(resolvePdfFontName(family, bold, italic))
```

to a single `fontManager.resolveFont(family, bold, italic)` — which is what that ternary was trying to
express. The renderer diff is a net deletion.

The rest follows from holding faces rather than a font:

- `measureText`, `getFontAscent`, `getFontDescent`, `getLineHeight`, `isEmbeddedFont` and `encodeText`
  look the face up by resource name, so each face has its own metrics and its own subset CID map.
- `writeFontResources` embeds one subset per registered face.
- `resolveRenderResourceName` recovers the style from the Type1 name it is handed
  (`Helvetica-BoldOblique`, `Times-Italic`, …), so text drawn against a Type1 resource *before* a font
  was embedded — the auto-discovery path — still lands on the right face instead of being flattened.
- `hasEmbeddedFont()` stays truthful, so `registerAutoDiscoveredFont()`, `needsType3()` and the
  `hasType3Fonts() && !hasEmbeddedFont()` checks keep working unchanged.

### One tradeoff to flag

Every face is subsetted over the document's full tracked code point set. Code points are tracked per
document rather than per run, so there is no way to know which of them a given face actually draws,
and covering all of them in each face is what guarantees a run can switch style without hitting
`.notdef`. A document that registers a single face is unaffected.

Per-face tracking would tighten this, but it means threading style through `trackText` at every call
site — happy to do it in this PR or a follow-up if you'd prefer that.

`document-builder.ts`'s `embedFont` still takes a single font. Extending the builder API the same way
is a natural follow-up; I left it out to keep this PR to one feature.

## Test plan

New file `src/modules/pdf/__tests__/font-faces.test.ts` — 24 tests covering style→face routing, each
fallback chain, per-face metrics, per-face subset encoding, re-registering a style, deferred Type1
routing, and end-to-end `excelToPdf` behaviour.

The end-to-end assertions inflate the content stream and map each `Tf` operator back to the `BaseFont`
it selects, so they check which face actually drew each run rather than just which fonts got embedded.
A sheet with a bold cell, an italic cell and a plain cell now draws through three faces; before this
change all three selected the same one.

```bash
pnpm check                            # clean
pnpm exec vitest run src/modules/pdf  # 889 passed (865 existing + 24 new)
pnpm exec vitest run                  # 16842 passed
```

The full suite shows 4 failures on my machine, all of which reproduce identically on an unmodified
`main`: one LibreOffice chart-oracle test (LibreOffice not installed) and three Node stream-semantics
tests. I did not run `pnpm test:browser` locally — no Playwright Chromium here.

## Checklist

- [x] Tests pass locally
- [x] Code follows project style (ran `pnpm check`)
- [x] Added/updated tests for changes
- [x] Updated documentation if needed — the option is documented via TSDoc on `PdfExportOptions`;
      `docs/` has no page covering export options.
