### PR TITLE
fix(pdf): keep glyph left side bearings when subsetting embedded fonts

### DIFF
--- a/src/modules/pdf/__tests__/font-embedding.test.ts
+++ b/src/modules/pdf/__tests__/font-embedding.test.ts
@@ -1,6 +1,10 @@
+import { inflateSync } from "node:zlib";
+
 import { createWorkbook, addWorksheet } from "@excel/core/workbook";
 import { Cell } from "@excel/index";
+import { PdfWriter } from "@pdf/core/pdf-writer";
 import { PdfFontError } from "@pdf/errors";
+import { embedTtfFont } from "@pdf/font/font-embedder";
 import { FontManager } from "@pdf/font/font-manager";
 import { parseTtf } from "@pdf/font/ttf-parser";
 /**
@@ -8,7 +12,7 @@ import { parseTtf } from "@pdf/font/ttf-parser";
  */
 import { describe, it, expect } from "vitest";
 
-import { buildMinimalTtf, buildSparseGidTtf } from "./ttf-test-utils";
+import { buildMinimalTtf, buildSparseGidTtf, buildTtfWithCmap } from "./ttf-test-utils";
 
 // =============================================================================
 // Tests
@@ -109,6 +113,58 @@ describe("Font Embedding Utilities", () => {
     // A=600, B=550 in font units, unitsPerEm=1000
     // (600 + 550) / 1000 * 12 = 13.8
     expect(width).toBeCloseTo(13.8, 1);
+  });
+});
+
+describe("Subset Horizontal Metrics", () => {
+  // A→GID 5, B→GID 8, so the subset has to remap as well as copy.
+  const BEARINGS = [40, 0, 0, 0, 0, -35, 0, 0, 120, 0];
+  const WIDTHS = Array.from({ length: 10 }, (_, i) => 500 + i * 10);
+
+  function buildBearingTtf(): Uint8Array {
+    return buildTtfWithCmap(
+      [
+        { start: 0x41, end: 0x41, delta: 5 - 0x41 },
+        { start: 0x42, end: 0x42, delta: 8 - 0x42 }
+      ],
+      10,
+      { advanceWidths: WIDTHS, leftSideBearings: BEARINGS }
+    );
+  }
+
+  /** Inflate the subset font program the embedder wrote into `writer`. */
+  function subsetProgram(writer: PdfWriter): Uint8Array {
+    const stream = writer.getObjects().find(o => o.content.includes("/Length1"));
+    if (!stream?.streamData) {
+      throw new Error("no embedded font program was written");
+    }
+    return new Uint8Array(inflateSync(stream.streamData));
+  }
+
+  it("should read left side bearings, including negative ones", () => {
+    const font = parseTtf(buildBearingTtf());
+
+    expect(font.leftSideBearings[0]).toBe(40);
+    expect(font.leftSideBearings[5]).toBe(-35); // 'A'
+    expect(font.leftSideBearings[8]).toBe(120); // 'B'
+  });
+
+  it("should carry left side bearings into the subset font", () => {
+    // A rasterizer positions an outline by translating it by `lsb - xMin`, so a
+    // subset that drops the bearing draws every glyph's ink at the pen position
+    // instead of at `pen + xMin`. The damage is invisible in the advance widths
+    // and shows up as glyphs drifting inside their own advance — most visibly
+    // for a glyph like 'j', whose outline reaches left of the pen.
+    const writer = new PdfWriter();
+    const font = parseTtf(buildBearingTtf());
+    embedTtfFont(writer, font, new Set([0x41, 0x42]), "EF1");
+
+    // Used glyphs sorted: [.notdef, 5, 8] → subset GIDs [0, 1, 2].
+    const subset = parseTtf(subsetProgram(writer));
+
+    expect(subset.numGlyphs).toBe(3);
+    expect(Array.from(subset.leftSideBearings)).toEqual([40, -35, 120]);
+    expect(Array.from(subset.advanceWidths)).toEqual([WIDTHS[0], WIDTHS[5], WIDTHS[8]]);
   });
 });
 

--- a/src/modules/pdf/__tests__/ttf-test-utils.ts
+++ b/src/modules/pdf/__tests__/ttf-test-utils.ts
@@ -171,6 +171,12 @@ function assembleTtfFromTables(tables: Array<{ tag: string; data: Uint8Array }>)
 interface TtfBuildOptions {
   /** Per-glyph advance widths. Length must equal `numGlyphs`. Falls back to 500 for each glyph. */
   advanceWidths?: number[];
+  /**
+   * Per-glyph left side bearings. Length must equal `numGlyphs`. Falls back to 0
+   * for each glyph. May be negative, as it is for glyphs like `j` whose outline
+   * reaches left of the pen position.
+   */
+  leftSideBearings?: number[];
   /** Font family name written into the `name` table. Defaults to `"TestFont"`. */
   familyName?: string;
   /** PostScript name written into the `name` table. Defaults to `"<familyName>-Regular"`. */
@@ -188,6 +194,7 @@ export function buildTtfWithCmap(
   options?: TtfBuildOptions
 ): Uint8Array {
   const widths = options?.advanceWidths;
+  const bearings = options?.leftSideBearings;
   const family = options?.familyName ?? "TestFont";
   const ps = options?.postScriptName ?? `${family}-Regular`;
 
@@ -293,7 +300,7 @@ export function buildTtfWithCmap(
   const hmtxV = new DataView(hmtx.buffer);
   for (let i = 0; i < numGlyphs; i++) {
     hmtxV.setUint16(i * 4, widths?.[i] ?? 500, false);
-    hmtxV.setInt16(i * 4 + 2, 0, false);
+    hmtxV.setInt16(i * 4 + 2, bearings?.[i] ?? 0, false);
   }
   tables.push({ tag: "hmtx", data: hmtx });
 

--- a/src/modules/pdf/font/font-embedder.ts
+++ b/src/modules/pdf/font/font-embedder.ts
@@ -287,12 +287,16 @@ function subsetTtfFont(
   }
 
   // --- Rebuild hmtx ---
+  // Both metrics are copied from the source font. The left side bearing matters
+  // as much as the advance width: a rasterizer translates a glyph's outline by
+  // `lsb - xMin`, so writing a constant here would draw every glyph's ink at the
+  // pen position instead of at `pen + xMin`.
   const newHmtx = new Uint8Array(numGlyphs * 4);
   const hmtxView = new DataView(newHmtx.buffer);
   for (let i = 0; i < sortedOldGids.length; i++) {
     const oldGid = sortedOldGids[i];
     hmtxView.setUint16(i * 4, font.advanceWidths[oldGid] ?? 0, false);
-    hmtxView.setInt16(i * 4 + 2, 0, false); // lsb = 0 (simplified)
+    hmtxView.setInt16(i * 4 + 2, font.leftSideBearings[oldGid] ?? 0, false);
   }
 
   // --- Rebuild cmap (format 12 for full Unicode) ---

--- a/src/modules/pdf/font/ttf-parser.ts
+++ b/src/modules/pdf/font/ttf-parser.ts
@@ -100,6 +100,16 @@ export interface TtfFont {
   /** Advance widths per glyph ID (in font units) */
   readonly advanceWidths: Uint16Array;
 
+  /**
+   * Left side bearings per glyph ID (in font units).
+   *
+   * A rasterizer positions a glyph's outline by translating it by
+   * `lsb - xMin`, so a subset font has to ship these unchanged: a bearing that
+   * disagrees with the outline it belongs to moves the glyph inside its own
+   * advance width.
+   */
+  readonly leftSideBearings: Int16Array;
+
   /** Glyph offsets (from loca table), used for subsetting */
   readonly glyphOffsets: Uint32Array;
 }
@@ -292,7 +302,12 @@ function parseTtfFromMagic(data: Uint8Array, r: BEReader, sfVersion: number): Tt
   const cmap = readCmap(r, tables.get("cmap")!);
 
   // --- hmtx table ---
-  const advanceWidths = readHmtx(r, tables.get("hmtx")!, hhea.numHMetrics, maxp.numGlyphs);
+  const { advanceWidths, leftSideBearings } = readHmtx(
+    r,
+    tables.get("hmtx")!,
+    hhea.numHMetrics,
+    maxp.numGlyphs
+  );
 
   // --- loca table ---
   const glyphOffsets =
@@ -344,6 +359,7 @@ function parseTtfFromMagic(data: Uint8Array, r: BEReader, sfVersion: number): Tt
     tables,
     cmap,
     advanceWidths,
+    leftSideBearings,
     glyphOffsets
   };
 }
@@ -692,29 +708,39 @@ function readCmapFormat12(r: BEReader, offset: number): Map<number, number> {
 // =============================================================================
 
 /**
- * Read horizontal metrics. Returns advance widths for all glyphs.
+ * Read horizontal metrics. Returns the advance width and the left side bearing
+ * of every glyph.
+ *
+ * The table stores `numHMetrics` `longHorMetric` records (advance width + left
+ * side bearing), followed by a bare int16 array holding the left side bearings
+ * of the remaining monospaced-tail glyphs. A font may truncate that trailing
+ * array, so reads past the end of the table fall back to 0.
  */
 function readHmtx(
   r: BEReader,
   entry: TableEntry,
   numHMetrics: number,
   numGlyphs: number
-): Uint16Array {
+): { advanceWidths: Uint16Array; leftSideBearings: Int16Array } {
   const tr = r.at(entry.offset);
   const widths = new Uint16Array(numGlyphs);
+  const leftSideBearings = new Int16Array(numGlyphs);
+  const tableEnd = entry.offset + entry.length;
+  const nextLsb = (): number => (tr.offset + 2 <= tableEnd ? tr.i16() : 0);
 
   let lastWidth = 0;
   for (let i = 0; i < numHMetrics; i++) {
     lastWidth = tr.u16();
-    tr.skip(2); // lsb (left side bearing)
     widths[i] = lastWidth;
+    leftSideBearings[i] = nextLsb();
   }
-  // Remaining glyphs share the last advanceWidth
+  // Remaining glyphs share the last advanceWidth but keep their own bearing
   for (let i = numHMetrics; i < numGlyphs; i++) {
     widths[i] = lastWidth;
+    leftSideBearings[i] = nextLsb();
   }
 
-  return widths;
+  return { advanceWidths: widths, leftSideBearings };
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Subsetting an embedded font drops every glyph's left side bearing, which moves glyphs
inside their own advance width.

`subsetTtfFont` rebuilds `hmtx` as:

```ts
hmtxView.setUint16(i * 4, font.advanceWidths[oldGid] ?? 0, false);
hmtxView.setInt16(i * 4 + 2, 0, false); // lsb = 0 (simplified)
```

and it has no choice, because `readHmtx` reads the advance width and `tr.skip(2)`s the
bearing, so the real value never reaches `ParsedFont`.

A rasterizer positions a glyph by translating its outline by `lsb - xMin` — FreeType does
this unconditionally (`TT_Process_Simple_Glyph`: *"Translate array so that (0,0) is the
glyph's origin"*), so Chrome/pdfium and Acrobat follow. With a zeroed bearing every glyph's
ink is drawn at the pen position instead of at `pen + xMin`.

Advance widths stay correct, so line lengths and wrapping are unaffected and the damage is
easy to miss: most Latin lowercase glyphs have a similar positive xMin and the shift
largely cancels between neighbours. It becomes obvious as soon as a glyph with a very
different xMin appears. In Liberation Sans `j` is xMin −50 against ~130 for its neighbours,
so the pair `n j` gains ~0.09 em of gap:

| | rendered at 300 dpi |
|---|---|
| before | `Iskop za tlocrt ob jekta uklj učuj ući uklan jan je` |
| after | `Iskop za tlocrt objekta uključujući uklanjanje` |

(Same workbook, same font, `Pdf.fromExcel(wb, { fonts })`; the only difference is the
subset's `hmtx`.)

### The change

`parseTtf` now returns `leftSideBearings` alongside `advanceWidths`, and the subset writes
them through unchanged. `readHmtx` reads the bearing from each `longHorMetric` record and
then from the trailing bare int16 array that covers the monospaced tail, tolerating a font
that truncates it.

Nothing else moves: only the four embedded font programs differ between a before and after
render of the same document — every content stream, `/W` array and page object is
byte-identical.

## Test plan

Two tests in `src/modules/pdf/__tests__/font-embedding.test.ts`:

- the parser reads bearings, including negative ones;
- the subset carries them through, remapped with the GIDs — the font maps A→GID 5 and
  B→GID 8, and the subset's `hmtx` must read `[40, -35, 120]`, not `[0, 0, 0]`.

The regression is invisible in advance widths, so a widths-only assertion would not catch
it; the second test fails with `expected [ +0, +0, +0 ] to deeply equal [ 40, -35, 120 ]`
on unmodified `main`. `ttf-test-utils`'s `buildTtfWithCmap` gained an optional
`leftSideBearings` option to make that expressible; existing builders are unchanged.

```bash
pnpm exec tsc --noEmit                # clean
pnpm exec oxlint                      # clean
pnpm exec oxfmt                       # no files changed
node scripts/verify-layers.ts         # ✓
node scripts/verify-public-types.ts   # ✓
pnpm exec vitest run src/modules/pdf  # 867 passed (865 existing + 2 new)
pnpm exec vitest run                  # 16821 passed, 3 failed
```

The 3 failures are pre-existing on `main` — verified by stashing the change and running
`vitest run src/modules/stream` on an unmodified tree: same 3 failures, same names (Node
stream-semantics tests). Not run locally: `pnpm test:browser`, which needs Playwright
Chromium; CI covers it. `pnpm check` itself could not be run as one command here (no pnpm
on this machine), so its five steps were run individually as shown.

## Checklist

- [x] Tests pass locally
- [x] Code follows project style (`oxlint` and `oxfmt` clean)
- [x] Added/updated tests for changes
- [x] Updated documentation if needed — no user-facing API change; the reasoning lives in
      TSDoc on `ParsedFont.leftSideBearings` and next to the `hmtx` rebuild
